### PR TITLE
Issue-31: Move removal of queued card to AFTER we do on_card_play

### DIFF
--- a/Cards/CardContainer.gd
+++ b/Cards/CardContainer.gd
@@ -61,6 +61,7 @@ func set_queued_card(card: CardWorld) -> void:
 
 
 func remove_queued_card() -> void:
+	_focused_card = null
 	_cards_queued_for_discard.append(queued_card)
 	_remove_queued_card_from_hand()
 	set_queued_card(null)
@@ -85,15 +86,18 @@ func finish_active_card_action(card: CardBase) -> void:
 
 
 func _discard_active_card() -> void:
-	var _card_to_discard = null
-	for card_index in _cards_queued_for_discard.size():
-		if (_cards_queued_for_discard[card_index].card_data == _active_card):
-			_card_to_discard = _cards_queued_for_discard[card_index]
+	var _card_to_discard = _find_active_card_in_queued_discard_list()
 
 	if _card_to_discard != null:
 		discard_pile.append(_card_to_discard.card_data)
 		_handle_discard_queue()
 		on_card_counts_updated.emit()
+
+func _find_active_card_in_queued_discard_list() -> CardWorld:
+	for card_index in _cards_queued_for_discard.size():
+		if (_cards_queued_for_discard[card_index].card_data == _active_card):
+			return _cards_queued_for_discard[card_index]
+	return null
 
 
 func are_cards_active() -> bool:

--- a/Cards/CardContainer.gd
+++ b/Cards/CardContainer.gd
@@ -93,8 +93,7 @@ func finish_active_card_action(card: CardBase) -> void:
 func _discard_active_card() -> void:
 	if (_active_card != null):
 		# Add active_card to discard queued to trigger the discard animation
-		_cards_queued_for_discard.append(_active_card)
-		_handle_discard_queue()
+		_add_to_discard_queue(_active_card)
 		
 		# Add to the discard pile to update the counter
 		discard_pile.append(_active_card.card_data)

--- a/Cards/CardContainer.gd
+++ b/Cards/CardContainer.gd
@@ -47,7 +47,7 @@ var _discard_timer: SceneTreeTimer = null
 func _ready() -> void:
 	PhaseManager.on_phase_changed.connect(_on_phase_changed)
 	CardManager.set_card_container(self)
-	CardManager.on_card_action_finished.connect(remove_active_card)
+	CardManager.on_card_action_finished.connect(finish_active_card_action)
 	
 	_init_default_draw_pile()
 
@@ -61,9 +61,14 @@ func set_queued_card(card: CardWorld) -> void:
 
 
 func remove_queued_card() -> void:
-	_focused_card = null
-	discard_card(queued_card)
+	_cards_queued_for_discard.append(queued_card)
+	_remove_queued_card_from_hand()
 	set_queued_card(null)
+
+
+func _remove_queued_card_from_hand() -> void:
+	var _index_to_remove = cards_in_hand.find(queued_card)
+	cards_in_hand.remove_at(_index_to_remove)
 
 
 func is_card_queued() -> bool:
@@ -74,8 +79,21 @@ func set_active_card(card: CardBase) -> void:
 	_active_card = card
 
 
-func remove_active_card(card: CardBase) -> void:
+func finish_active_card_action(card: CardBase) -> void:
+	_discard_active_card()
 	_active_card = null
+
+
+func _discard_active_card() -> void:
+	var _card_to_discard = null
+	for card_index in _cards_queued_for_discard.size():
+		if (_cards_queued_for_discard[card_index].card_data == _active_card):
+			_card_to_discard = _cards_queued_for_discard[card_index]
+
+	if _card_to_discard != null:
+		discard_pile.append(_card_to_discard.card_data)
+		_handle_discard_queue()
+		on_card_counts_updated.emit()
 
 
 func are_cards_active() -> bool:

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -98,6 +98,6 @@ func _try_player_play_card_on_entity(entity: Entity) -> void:
 		if can_play:
 			# remove queued card, then play the card
 			# This is so the queued card doesn't have any influence over our hand count
+			CardManager.card_container.remove_queued_card()
 			CardManager.card_container.set_active_card(queued_card_data)
 			queued_card_data.on_card_play(PlayerManager.player, entity)
-			CardManager.card_container.remove_queued_card()

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -98,6 +98,6 @@ func _try_player_play_card_on_entity(entity: Entity) -> void:
 		if can_play:
 			# remove queued card, then play the card
 			# This is so the queued card doesn't have any influence over our hand count
-			CardManager.card_container.remove_queued_card()
 			CardManager.card_container.set_active_card(queued_card_data)
 			queued_card_data.on_card_play(PlayerManager.player, entity)
+			CardManager.card_container.remove_queued_card()

--- a/Tests/test_cards.gd
+++ b/Tests/test_cards.gd
@@ -130,17 +130,20 @@ func test_play_card_action_flow():
 	assert_true(_card_container.is_card_queued(), "Card has not been queued yet.")
 
 	# Simulate removing queued card to set it to active
-	_card_container.remove_queued_card()
+	_card_container.queued_for_active()
 
 	assert_eq(_card_container.cards_in_hand.size(), 9, "Card has not been removed from hand")
-	assert_false(_card_container.is_card_queued(), "Card is still queued.")
-	assert_eq(_card_container._cards_queued_for_discard.size(), 1, "Card to remove from hand has not been queued for discard.")
 	assert_eq(_card_container.discard_pile.size(), 0, "Discard pile has been populated too early")
 
 	# Simulate setting active card to play
-	_card_container.set_active_card(_queued_card.card_data)
-
+	_card_container.set_active_card(_queued_card)
+	
 	assert_true(_card_container.are_cards_active(), "No card is currently active")
+	
+	# Removed the queued card
+	_card_container.set_queued_card(null)
+	
+	assert_false(_card_container.is_card_queued(), "Card is still queued.")
 
 	# Simulate finishing the card action
 	_card_container.finish_active_card_action(_queued_card.card_data)


### PR DESCRIPTION
# Description

Updated the card action play flow to separate out the removal from the card hand from adding it to the discard pile in order to help facilitate Draw Card actions potentially drawing itself.

## Related issue(s)

Closes #31 

## List of changes

A more detailed list of the changes.
- Updated `_active_card` variable to CardWorld to help with discarding logic
- Update naming of play_card flow for more clarity
- Update play_card flow to the following:
    - Prepare the queued_card to active, by removing it from the cards_in_hands and setting focused_card to null
    - Set the queued_card to active_card then remove the queued_card
    - Play the active_card
- Update PLAYER_FINISHED logic in `_on_phased_changed()` to call `on_finished_discarding_hand` signal
- Renamed `remove_active_card()` to `finish_active_card_action()` to call `discard_active_card()`
- Added `_discard_active_card()` to execute card animation to discard pile and add it to the discard pile

## Tests

Added a test to `test_cards.gd` to test the card action flow.

## Additional notes

I'm on the fence on this change, cause moving the remove_queued_card() call DOES indeed ensure that discard happens AFTER the card is played, but we're also removing it from the queue. I'm thinking if I want to separate out the removal from queue and the discarding of the card, just to not rock the loop TOO much.
