### PR TITLE
Issue-53: Fix cards getting stuck in hovered state

### DIFF
--- a/Cards/Card.tscn
+++ b/Cards/Card.tscn
@@ -17,7 +17,7 @@ script = ExtResource("1_4el5m")
 
 [node name="ClickHandler" type="Node" parent="."]
 script = ExtResource("3_du4nn")
-lock_hover_time = 0.3
+time_to_lock_hover = 0.3
 
 [node name="CardMovementComponent" type="Node" parent="."]
 script = ExtResource("6_qvt2l")

--- a/Cards/Card.tscn
+++ b/Cards/Card.tscn
@@ -17,6 +17,7 @@ script = ExtResource("1_4el5m")
 
 [node name="ClickHandler" type="Node" parent="."]
 script = ExtResource("3_du4nn")
+lock_hover_time = 0.3
 
 [node name="CardMovementComponent" type="Node" parent="."]
 script = ExtResource("6_qvt2l")

--- a/Input/ClickHandler.gd
+++ b/Input/ClickHandler.gd
@@ -15,15 +15,15 @@ signal on_mouse_hovering
 
 # If greater than 0, then on_mouse_hovering will not trigger for the set time after an unhover event
 # NOTE: this is needed because InputEventMouseMotion will sometimes fire after mouse_exited events
-@export var lock_hover_time: float = 0.0
+@export var time_to_lock_hover: float = 0.0
 
 var _is_interactable: bool = true
 var _lock_hover_timer: Timer = null
 var _hover_enabled = true
 
 
-func _ready():
-	if lock_hover_time > 0.0:
+func _ready() -> void:
+	if time_to_lock_hover > 0.0:
 		_create_lock_hover_timer()
 
 
@@ -67,7 +67,7 @@ func _on_mouse_exited() -> void:
 	on_unhover.emit()
 
 
-func _create_lock_hover_timer():
+func _create_lock_hover_timer() -> void:
 	_lock_hover_timer = Timer.new()
 	add_child(_lock_hover_timer)
 	
@@ -75,11 +75,11 @@ func _create_lock_hover_timer():
 	_lock_hover_timer.timeout.connect(func(): _hover_enabled = true)
 
 
-func _set_lock_hover_timer():
+func _set_lock_hover_timer() -> void:
 	if _lock_hover_timer == null:
 		return
 	
 	# Disable hovering, set timer. When timer expires, hovering will re-enable.
 	_hover_enabled = false
 	_lock_hover_timer.stop()
-	_lock_hover_timer.start(lock_hover_time)
+	_lock_hover_timer.start(time_to_lock_hover)

--- a/Input/ClickHandler.gd
+++ b/Input/ClickHandler.gd
@@ -22,6 +22,11 @@ var _lock_hover_timer: Timer = null
 var _hover_enabled = true
 
 
+func _ready():
+	if lock_hover_time > 0.0:
+		_create_lock_hover_timer()
+
+
 func set_interactable(interactable: bool) -> void:
 	if not interactable:
 		on_unhover.emit()
@@ -62,16 +67,19 @@ func _on_mouse_exited() -> void:
 	on_unhover.emit()
 
 
-func _set_lock_hover_timer():
-	if lock_hover_time <= 0.0:
-		return
-	
-	if _lock_hover_timer != null:
-		_lock_hover_timer.stop()
-	
-	# Disable hovering, set timer. When timer expires, re-enable hovering
-	_hover_enabled = false
+func _create_lock_hover_timer():
 	_lock_hover_timer = Timer.new()
 	add_child(_lock_hover_timer)
+	
+	# When timer expires, enable hovering
 	_lock_hover_timer.timeout.connect(func(): _hover_enabled = true)
+
+
+func _set_lock_hover_timer():
+	if _lock_hover_timer == null:
+		return
+	
+	# Disable hovering, set timer. When timer expires, hovering will re-enable.
+	_hover_enabled = false
+	_lock_hover_timer.stop()
 	_lock_hover_timer.start(lock_hover_time)


### PR DESCRIPTION
# Description

This fixes issue #53 by adding a `lock_hover_time` in `ClickHandler`.

## Related issue(s)

#53 

## List of changes

Adds a `lock_hover_time` to the ClickHandler. Setting a non-zero value will set a timer when a card is unhovered, blocking `on_mouse_hovering` signals.

## Additional notes

This is a very strange issue. What I discovered is that Godot will sometimes fire `InputEventMouseMotion` after the `mouse_exit` event. So when a card is unhovered, it entered the `IN_HAND` state, but then the `_on_gui_input_event` of `ClickHandler` would sometimes still trigger the `InputEventMouseMotion` again putting the card back into the `HOVERED` state. The timer locks the `on_mouse_hovering` event from firing for a very short period after the card is unhovered.
