### PR TITLE
Issue-51: Update GUT Tests to assert if there are no orphans (#52)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: croconut/godot-tester@v5.1
+    - uses: Tysterman74/godot-tester@master
       with:
         # required
         version: "4.2.1"

--- a/Tests/test_cards.gd
+++ b/Tests/test_cards.gd
@@ -29,6 +29,7 @@ func before_each():
 
 func after_each():
 	_card_container.queue_free()
+	assert_no_new_orphans("Orphans still exist, please free up test resources.")
 
 
 func test_draw_cards():

--- a/Tests/test_eventbase.gd
+++ b/Tests/test_eventbase.gd
@@ -6,6 +6,9 @@ var eventBase: EventBase = null
 func before_each():
 	eventBase = EventBase.new()
 
+func after_each():
+	assert_no_new_orphans("Orphans still exist, please free up test resources.")
+
 func test_event_base_array_all_types():
 	var event0 = GlobalVar.EVENTS_CLASSIFICATION[0]
 	assert_eq(event0, EventMob)

--- a/Tests/test_health.gd
+++ b/Tests/test_health.gd
@@ -29,6 +29,7 @@ func after_each():
 	_player.queue_free()
 	_enemy.queue_free()
 	_battler.queue_free()
+	assert_no_new_orphans("Orphans still exist, please free up test resources.")
 
 
 func test_take_damage():

--- a/Tests/test_pile_ui.gd
+++ b/Tests/test_pile_ui.gd
@@ -30,6 +30,7 @@ func before_each():
 func after_each():
 	_card_container.free()
 	_card_scroll.free()
+	assert_no_new_orphans("Orphans still exist, please free up test resources.")
 	
 func test_populate():
 	


### PR DESCRIPTION
# Description

Moving changes from #52 into `map-implementation` branch

## Related issue(s)

#52

## List of changes

- Update CI.yml to use my forked action of the action workflow we're using
    - Added -d to my forked action to run the Godot command in debug, which throws an error if there are compiler errors
- Updated all test suites that are instantiating objects to check for assert_no_new_orphans("Orphans still exist, please free up test resources.")


## Tests

Updated test_cards.gd, test_health.gd, and test_pile_ui.gd to check for no new orphans.

## Additional notes

Excluded out `test_stats.gd` since `map-implementation` hasn't been synced up with `main`.
