### PR TITLE
Auto-focus map display on player position 

### DIFF
--- a/UI/MapUI.gd
+++ b/UI/MapUI.gd
@@ -167,9 +167,9 @@ func _ready() -> void:
 	room_container.add_child(light_overlay)
 	
 	if(!PlayerManager.is_player_initial_position_set):
-		scroll_container.scroll_to_bottom()
+		scroll_container.scroll_to_bottom(0)
 	else:
-		scroll_container.scroll_to_fauna()
+		scroll_container.scroll_to_fauna(0)
 
 # Get the width of room nodes, by getting the size of what a room is w/ some offset
 # multiplying that by the max number in the map_width_array to get the width of the largest floor then add offset 

--- a/UI/MapUI.gd
+++ b/UI/MapUI.gd
@@ -165,6 +165,11 @@ func _ready() -> void:
 	
 	light_overlay = LightOverlay.new(room_container, room_ui_array, offset_x, offset_y)
 	room_container.add_child(light_overlay)
+	
+	if(!PlayerManager.is_player_initial_position_set):
+		scroll_container.scroll_to_bottom()
+	else:
+		scroll_container.scroll_to_fauna()
 
 # Get the width of room nodes, by getting the size of what a room is w/ some offset
 # multiplying that by the max number in the map_width_array to get the width of the largest floor then add offset 

--- a/UI/MapUI.gd
+++ b/UI/MapUI.gd
@@ -80,7 +80,7 @@ func _ready() -> void:
 	# Set the max width between what we calculated above and the minimum room width constant
 	room_container_width = max(room_container_width, _MINIMUM_ROOM_WIDTH)
 	
-	var room_container_height: float = _get_combined_room_height(new_room_texture_button)
+	var room_container_height: float = get_combined_room_height(new_room_texture_button)
 	# Set the max height between what we calculated above and the minimum room height constant
 	room_container_height = max(room_container_height, _MINIMUM_ROOM_HEIGHT)
 	
@@ -156,8 +156,8 @@ func _ready() -> void:
 	var new_room_position_y: float = room_container.position.y
 	# Get the offset if we had to adjust the Y position due to having to set a minimum height if the map is too small.
 	var offset_y: float = 0
-	if (_get_combined_room_height(new_room_texture_button) < _MINIMUM_ROOM_HEIGHT):
-		new_room_position_y = room_container.position.y - room_container.get_custom_minimum_size().y / 2 + _get_combined_room_height(new_room_texture_button) / 2
+	if (get_combined_room_height(new_room_texture_button) < _MINIMUM_ROOM_HEIGHT):
+		new_room_position_y = room_container.position.y - room_container.get_custom_minimum_size().y / 2 + get_combined_room_height(new_room_texture_button) / 2
 		offset_y = room_addition_node.position.y - new_room_position_y
 	room_addition_node.set_position(Vector2(new_room_position_x, new_room_position_y))
 	
@@ -180,7 +180,7 @@ func _get_combined_room_width(texture_rect: TextureButton) -> float:
 # Calculate the height of the container where the rooms will reside in. This will be dynamic based on the map array that we have.
 # The array we have in MapManager, each element will increase the height of the map display, 
 # multiply by the size of a room w/ some offset to dynamically set the size of the container of which we will be scrolling.
-func _get_combined_room_height(texture_rect: TextureButton) -> float:
+func get_combined_room_height(texture_rect: TextureButton) -> float:
 	return MapManager.map_width_array.size() * (texture_rect.get_size().y + _padding_offset) + _padding_offset
 
 # Callback function for when a player selects a room

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -636,13 +636,11 @@ func scroll_to_fauna(duration:float=0.5) -> void:
 	
 	var room_distance: float = 66
 	var scroll_to_pos:float = -room_distance
-	var rooms_between_fauna_and_top = MapManager.map_width_array.size() - 8
+	var rooms_between_fauna_and_top : int = MapManager.map_width_array.size() - 8
 	
 	scroll_to_pos -= (rooms_between_fauna_and_top - PlayerManager.player_position.y) * room_distance 
 	
 	scroll_y_to(scroll_to_pos)
-	
-	pass
 
 
 func is_outside_top_boundary(y_pos: float = pos.y) -> bool:

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -630,6 +630,21 @@ func scroll_to_left(duration:float=0.5) -> void:
 func scroll_to_right(duration:float=0.5) -> void:
 	scroll_x_to(self.size.x - content_node.size.x, duration)
 
+func scroll_to_fauna(duration:float=0.5) -> void:
+	if(!PlayerManager.is_player_initial_position_set):
+		return
+	
+	var room_distance: float = 66
+	var scroll_to_pos:float = -room_distance
+	var rooms_between_fauna_and_top = MapManager.map_width_array.size() - 8
+	
+	scroll_to_pos -= (rooms_between_fauna_and_top - PlayerManager.player_position.y) * room_distance 
+	
+	scroll_y_to(scroll_to_pos)
+	
+	pass
+
+
 func is_outside_top_boundary(y_pos: float = pos.y) -> bool:
 	return y_pos > 0.0
 

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -634,11 +634,16 @@ func scroll_to_fauna(duration:float=0.5) -> void:
 	if(!PlayerManager.is_player_initial_position_set):
 		return
 	
-	var room_distance: float = 66
-	var scroll_to_pos:float = -room_distance
-	var rooms_between_fauna_and_top : int = MapManager.map_width_array.size() - 8
+	var map_UI : MapUI = get_parent()
+	var current_map_texure_button : TextureButton = Helpers.get_first_child_node_of_type(map_UI.current_player_room, TextureButton)
 	
-	scroll_to_pos -= (rooms_between_fauna_and_top - PlayerManager.player_position.y) * room_distance 
+	var max_scroll = content_node.size.y - self.size.y
+	var room_distance : float = map_UI.get_combined_room_height(current_map_texure_button) / MapManager.current_map.rooms.size()
+	var scroll_to_pos : float = -max_scroll
+	
+	var rooms_behind_seen : int = 1
+	
+	scroll_to_pos += room_distance * (PlayerManager.player_position.y - rooms_behind_seen)
 	
 	scroll_y_to(scroll_to_pos)
 

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -635,7 +635,7 @@ func scroll_to_fauna(duration:float=0.5) -> void:
 		return
 	
 	var map_UI : MapUI = get_parent()
-	var current_map_texure_button : TextureButton = Helpers.get_first_child_node_of_type(map_UI.current_player_room, TextureButton)
+	var current_map_texure_button : TextureButton = map_UI.current_player_room.button
 	
 	var max_scroll = content_node.size.y - self.size.y
 	var room_distance : float = map_UI.get_combined_room_height(current_map_texure_button) / MapManager.current_map.rooms.size()

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -645,7 +645,7 @@ func scroll_to_fauna(duration:float=0.5) -> void:
 	
 	scroll_to_pos += room_distance * (PlayerManager.player_position.y - rooms_behind_seen)
 	
-	scroll_y_to(scroll_to_pos)
+	scroll_y_to(scroll_to_pos, duration)
 
 
 func is_outside_top_boundary(y_pos: float = pos.y) -> bool:


### PR DESCRIPTION
# Description

Scrolls the map to fauna when entered or to the bottom if fauna is not instanced

## List of changes

Added function to SmoothScrollContainer to scroll_to_fauna
MapUi script calls SmoothScroll on _ready

## Additional notes

The scroll_to_fauna function uses the MapManager's current_map's room array size to figure out how many rooms are in the current_map, which might be problematic if that is changed significantly in the future

