### PR TITLE
 Stress bar mechanic

### DIFF
--- a/#Scenes/Events/mob/0.tscn
+++ b/#Scenes/Events/mob/0.tscn
@@ -25,7 +25,7 @@ metadata/_edit_vertical_guides_ = [1216.0]
 script = ExtResource("3_fnmf8")
 
 [node name="Player" parent="." instance=ExtResource("4_ss8ob")]
-position = Vector2(595, 284)
+position = Vector2(595, 350)
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 

--- a/Cards/CardSets/DefaultDeck.tres
+++ b/Cards/CardSets/DefaultDeck.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="CardSetBase" load_steps=20 format=3 uid="uid://cda81lacxt2ai"]
+[gd_resource type="Resource" script_class="CardSetBase" load_steps=21 format=3 uid="uid://cda81lacxt2ai"]
 
 [ext_resource type="Script" path="res://Cards/CardSetBase.gd" id="1_pnxc0"]
 [ext_resource type="Resource" uid="uid://dam752rc15nu5" path="res://Cards/Resource/Card_Buff_Poison_Duration.tres" id="1_to4gc"]
@@ -19,7 +19,8 @@
 [ext_resource type="Resource" uid="uid://yc2ns5s0qask" path="res://Cards/Resource/Card_SuperSlap.tres" id="16_jluts"]
 [ext_resource type="Resource" uid="uid://c787doijq7xg2" path="res://Cards/Resource/Card_Buff_healing.tres" id="17_0kgrg"]
 [ext_resource type="Resource" uid="uid://bek3vbtsf3x2l" path="res://Cards/Resource/Card_Debuff_healing.tres" id="18_uj8io"]
+[ext_resource type="Resource" uid="uid://wkffjp5doca1" path="res://Cards/Resource/Card_Stress_Damage.tres" id="19_s1aj2"]
 
 [resource]
 script = ExtResource("1_pnxc0")
-card_set = Array[Resource("res://Cards/CardBase.gd")]([ExtResource("1_to4gc"), ExtResource("2_q7qqo"), ExtResource("3_4ka0y"), ExtResource("4_es3ma"), ExtResource("5_giy28"), ExtResource("6_gr534"), ExtResource("7_y1gya"), ExtResource("8_haia1"), ExtResource("9_1tkbv"), ExtResource("10_7m46u"), ExtResource("11_0eivv"), ExtResource("12_lo5f6"), ExtResource("13_v3qs7"), ExtResource("14_ghttq"), ExtResource("15_ie3pe"), ExtResource("16_jluts"), ExtResource("17_0kgrg"), ExtResource("18_uj8io")])
+card_set = Array[Resource("res://Cards/CardBase.gd")]([ExtResource("1_to4gc"), ExtResource("2_q7qqo"), ExtResource("3_4ka0y"), ExtResource("4_es3ma"), ExtResource("5_giy28"), ExtResource("6_gr534"), ExtResource("7_y1gya"), ExtResource("8_haia1"), ExtResource("9_1tkbv"), ExtResource("10_7m46u"), ExtResource("11_0eivv"), ExtResource("12_lo5f6"), ExtResource("13_v3qs7"), ExtResource("14_ghttq"), ExtResource("15_ie3pe"), ExtResource("16_jluts"), ExtResource("17_0kgrg"), ExtResource("18_uj8io"), ExtResource("19_s1aj2")])

--- a/Cards/Effects/EffectSooth.gd
+++ b/Cards/Effects/EffectSooth.gd
@@ -1,0 +1,15 @@
+class_name EffectSooth extends EffectBase
+## Sooth an entity. [br]
+##
+## This effect will reduce the amount of stress of the target entity. [br]
+## Modifier key is SOOTH. [br]
+
+
+## @Override [br]
+## Refer to [EffectBase]
+func apply_effect(caster: Entity, target: Entity, value: int) -> void:
+
+	# calculate modified sooth given caster and target stats
+	var sooth: int = EntityStats.get_value_modified_by_stats(GlobalEnums.PossibleModifierNames.SOOTH, caster, target, value)
+	
+	target.get_stress_component().modify_stress(sooth, caster, true)

--- a/Cards/Effects/EffectStress.gd
+++ b/Cards/Effects/EffectStress.gd
@@ -1,0 +1,12 @@
+class_name EffectStress extends EffectBase
+## Stress an enemy [br]
+##
+## This effect will stress an enemy, increasing its stress level by a certain amount. [br]
+## Modifier key is STRESS [br]
+
+## @Override
+## Refer to [EffectBase]
+func apply_effect(caster: Entity, target: Entity, value: int) -> void:
+	var stress_increase: int = EntityStats.get_value_modified_by_stats(GlobalEnums.PossibleModifierNames.STRESS, caster, target, value)
+	
+	target.get_stress_component().modify_stress(stress_increase, caster)

--- a/Cards/Resource/Card_Stress_Damage.tres
+++ b/Cards/Resource/Card_Stress_Damage.tres
@@ -1,0 +1,45 @@
+[gd_resource type="Resource" script_class="CardBase" load_steps=15 format=3 uid="uid://wkffjp5doca1"]
+
+[ext_resource type="Script" path="res://Cards/Effects/EffectDamage.gd" id="1_j6mcv"]
+[ext_resource type="Script" path="res://Cards/Effects/EffectData.gd" id="2_qpe8d"]
+[ext_resource type="Script" path="res://Cards/Targeting/TargetAllEnemies.gd" id="3_kblp8"]
+[ext_resource type="Script" path="res://Cards/Effects/EffectStress.gd" id="4_sttxr"]
+[ext_resource type="Script" path="res://Cards/Targeting/TargetingBase.gd" id="5_06ud4"]
+[ext_resource type="Script" path="res://Cards/EnergyData.gd" id="6_tktqq"]
+[ext_resource type="Script" path="res://Cards/CardBase.gd" id="7_mwudb"]
+
+[sub_resource type="Resource" id="Resource_0xkly"]
+script = ExtResource("1_j6mcv")
+
+[sub_resource type="Resource" id="Resource_n8t3e"]
+script = ExtResource("3_kblp8")
+
+[sub_resource type="Resource" id="Resource_erfad"]
+script = ExtResource("2_qpe8d")
+effect = SubResource("Resource_0xkly")
+value = 10
+targeting_function = SubResource("Resource_n8t3e")
+
+[sub_resource type="Resource" id="Resource_0kipv"]
+script = ExtResource("4_sttxr")
+
+[sub_resource type="Resource" id="Resource_l7ne0"]
+script = ExtResource("5_06ud4")
+
+[sub_resource type="Resource" id="Resource_l78bb"]
+script = ExtResource("2_qpe8d")
+effect = SubResource("Resource_0kipv")
+value = 10
+targeting_function = SubResource("Resource_l7ne0")
+
+[sub_resource type="Resource" id="Resource_j3owp"]
+script = ExtResource("6_tktqq")
+energy_cost = 1
+
+[resource]
+script = ExtResource("7_mwudb")
+application_type = 1
+card_title = "Stress damage"
+card_description = "Inflict 10 damage to all enemies and stress the targeted enemy by 10"
+card_effects_data = Array[ExtResource("2_qpe8d")]([SubResource("Resource_erfad"), SubResource("Resource_l78bb")])
+energy_info = SubResource("Resource_j3owp")

--- a/Cards/Resource/Card_buff_sooth.tres
+++ b/Cards/Resource/Card_buff_sooth.tres
@@ -1,0 +1,42 @@
+[gd_resource type="Resource" script_class="CardBase" load_steps=12 format=3 uid="uid://cuv4xnxuo5v4e"]
+
+[ext_resource type="Script" path="res://Cards/Effects/EffectApplyStatus.gd" id="1_048dj"]
+[ext_resource type="Script" path="res://Status/Buffs/Buff_Sooth.gd" id="2_wmqv4"]
+[ext_resource type="Script" path="res://Cards/Effects/EffectData.gd" id="3_lj874"]
+[ext_resource type="Script" path="res://Entity/Components/Stats/StatModifiers.gd" id="3_ugr2k"]
+[ext_resource type="Script" path="res://Cards/Targeting/TargetPlayer.gd" id="4_xotqq"]
+[ext_resource type="Script" path="res://Cards/CardBase.gd" id="5_73bhc"]
+
+[sub_resource type="Resource" id="Resource_3cfuw"]
+script = ExtResource("3_ugr2k")
+permanent_add = 0
+permanent_multiply = 1.0
+temporary_add = 1
+temporary_multiply = 1.0
+
+[sub_resource type="Resource" id="Resource_6mgrq"]
+script = ExtResource("2_wmqv4")
+infinite_duration = false
+status_turn_duration = 5
+status_power = 1.0
+status_modifier_base_value = SubResource("Resource_3cfuw")
+
+[sub_resource type="Resource" id="Resource_ond7c"]
+script = ExtResource("1_048dj")
+status_to_apply = SubResource("Resource_6mgrq")
+
+[sub_resource type="Resource" id="Resource_3w608"]
+script = ExtResource("4_xotqq")
+
+[sub_resource type="Resource" id="Resource_62w63"]
+script = ExtResource("3_lj874")
+effect = SubResource("Resource_ond7c")
+value = 0
+targeting_function = SubResource("Resource_3w608")
+
+[resource]
+script = ExtResource("5_73bhc")
+application_type = 0
+card_title = "Buff Sooth"
+card_description = "Player can sooth by 1 more for 5 turns"
+card_effects_data = Array[ExtResource("3_lj874")]([SubResource("Resource_62w63")])

--- a/Cards/Resource/Card_debuff_sooth.tres
+++ b/Cards/Resource/Card_debuff_sooth.tres
@@ -1,0 +1,42 @@
+[gd_resource type="Resource" script_class="CardBase" load_steps=12 format=3 uid="uid://b8vwac1aeweiy"]
+
+[ext_resource type="Script" path="res://Cards/Effects/EffectApplyStatus.gd" id="1_s0fhw"]
+[ext_resource type="Script" path="res://Status/Debuffs/Debuff_Sooth.gd" id="2_v0vvp"]
+[ext_resource type="Script" path="res://Entity/Components/Stats/StatModifiers.gd" id="3_ssm1f"]
+[ext_resource type="Script" path="res://Cards/Effects/EffectData.gd" id="4_wtnve"]
+[ext_resource type="Script" path="res://Cards/Targeting/TargetPlayer.gd" id="5_y670f"]
+[ext_resource type="Script" path="res://Cards/CardBase.gd" id="6_5diek"]
+
+[sub_resource type="Resource" id="Resource_4tvm0"]
+script = ExtResource("3_ssm1f")
+permanent_add = 0
+permanent_multiply = 1.0
+temporary_add = -1
+temporary_multiply = 1.0
+
+[sub_resource type="Resource" id="Resource_3fv80"]
+script = ExtResource("2_v0vvp")
+infinite_duration = false
+status_turn_duration = 5
+status_power = 1.0
+status_modifier_base_value = SubResource("Resource_4tvm0")
+
+[sub_resource type="Resource" id="Resource_vrvdx"]
+script = ExtResource("1_s0fhw")
+status_to_apply = SubResource("Resource_3fv80")
+
+[sub_resource type="Resource" id="Resource_1dfso"]
+script = ExtResource("5_y670f")
+
+[sub_resource type="Resource" id="Resource_6jvca"]
+script = ExtResource("4_wtnve")
+effect = SubResource("Resource_vrvdx")
+value = 0
+targeting_function = SubResource("Resource_1dfso")
+
+[resource]
+script = ExtResource("6_5diek")
+application_type = 0
+card_title = "Debuff sooth"
+card_description = "Debuff sooth of player by 1 for 5 turns"
+card_effects_data = Array[ExtResource("4_wtnve")]([SubResource("Resource_6jvca")])

--- a/Cards/Resource/Card_sooth.tres
+++ b/Cards/Resource/Card_sooth.tres
@@ -1,0 +1,25 @@
+[gd_resource type="Resource" script_class="CardBase" load_steps=8 format=3 uid="uid://qxm7k4pr54m2"]
+
+[ext_resource type="Script" path="res://Cards/Effects/EffectSooth.gd" id="1_hm611"]
+[ext_resource type="Script" path="res://Cards/Effects/EffectData.gd" id="2_7pqqv"]
+[ext_resource type="Script" path="res://Cards/Targeting/TargetingBase.gd" id="3_71nev"]
+[ext_resource type="Script" path="res://Cards/CardBase.gd" id="4_vy6oy"]
+
+[sub_resource type="Resource" id="Resource_1h02a"]
+script = ExtResource("1_hm611")
+
+[sub_resource type="Resource" id="Resource_tn885"]
+script = ExtResource("3_71nev")
+
+[sub_resource type="Resource" id="Resource_105p5"]
+script = ExtResource("2_7pqqv")
+effect = SubResource("Resource_1h02a")
+value = 10
+targeting_function = SubResource("Resource_tn885")
+
+[resource]
+script = ExtResource("4_vy6oy")
+application_type = 1
+card_title = "Sooth"
+card_description = "Sooth targeted enemy by 10 points"
+card_effects_data = Array[ExtResource("2_7pqqv")]([SubResource("Resource_105p5")])

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -163,7 +163,7 @@ func _check_and_handle_battle_end() -> bool:
 	if _enemy_list.is_empty():
 		PhaseManager.on_event_win.emit()
 		return true
-    
+	
 	return false    
 
 

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -83,10 +83,9 @@ func _on_enemy_start_turn() -> void:
 	
 	# generate list of enemy actions
 	for enemy: Enemy in _enemy_list:
-		var enemy_attack: CardBase = enemy.get_behavior_component().attack
 		var stress_comp: StressComponent = enemy.get_stress_component()
-		if stress_comp.has_hit_overstress:
-			enemy_attack = stress_comp.on_overstress()
+		var enemy_attack: CardBase = enemy.get_behavior_component().get_attack(stress_comp.has_hit_overstress)
+		
 		var enemy_action: EnemyAction = EnemyAction.new(enemy, enemy_attack, PlayerManager.player)
 		_enemy_action_list.append(enemy_action)
 	

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -83,6 +83,9 @@ func _on_enemy_start_turn() -> void:
 	# generate list of enemy actions
 	for enemy: Enemy in _enemy_list:
 		var enemy_attack: CardBase = enemy.get_behavior_component().attack
+		var stress_comp: StressComponent = enemy.get_stress_component()
+		if stress_comp.has_hit_overstress:
+			enemy_attack = stress_comp.on_overstress()
 		var enemy_action: EnemyAction = EnemyAction.new(enemy, enemy_attack, PlayerManager.player)
 		_enemy_action_list.append(enemy_action)
 	
@@ -101,6 +104,9 @@ func _handle_enemy_attack_queue() -> void:
 	
 	CardManager.on_card_action_finished.connect(_try_finish_enemy_attacks.unbind(1))
 	enemy_action.execute()
+	# Potentially reset enemy stress after attack if they were overstressed
+	enemy_action.caster.get_stress_component().checked_reset_stress()
+		
 
 
 ## Called when an enemy action is finished.

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -74,6 +74,7 @@ func _on_player_start_turn() -> void:
 func _on_enemy_start_turn() -> void:
 	# apply status
 	for enemy: Entity in _enemy_list:
+		enemy.get_stress_component().on_turn_start()
 		enemy.get_status_component().apply_turn_start_status()
 		
 	# if battle have ended, skip the rest of code

--- a/Entity/Components/BehaviorComponent.gd
+++ b/Entity/Components/BehaviorComponent.gd
@@ -8,6 +8,7 @@ class_name BehaviorComponent
 
 ## The attack that the enemy will do
 @export var attack: CardBase = null
+@export var overstress_attack: CardBase = null
 
 
 ## Setup the attack of the enemy [br]
@@ -23,4 +24,11 @@ func _ready() -> void:
 	attack.card_effects_data.append(basic_effect_data)
 	attack.application_type = GlobalEnums.ApplicationType.FRIENDLY_ONLY
 	
-
+	overstress_attack = StressComponent.on_overstress()
+	
+	
+func get_attack(has_hit_overstress: bool) -> CardBase:
+	if has_hit_overstress:
+		return overstress_attack
+	else:
+		return attack

--- a/Entity/Components/HealthComponent.gd
+++ b/Entity/Components/HealthComponent.gd
@@ -20,12 +20,6 @@ func _ready() -> void:
 	_set_health(max_health)
 
 
-## Used to emit the specific signal for this class [br]
-## Useful for classes that inherit from this one but want a different signal [br]
-func _emit_class_signal() -> void:
-	on_health_changed.emit(current_health)
-
-
 ## Modify the health of the entity [br]
 ## Use the is_healing boolean if you want to heal. [br]
 ## If the amount is negative, nothing will change. [br]
@@ -61,4 +55,4 @@ func _set_health(new_health: float) -> void:
 	if (new_health == current_health):
 		return
 	current_health = new_health
-	_emit_class_signal()
+	on_health_changed.emit(current_health)

--- a/Entity/Components/HealthComponent.gd
+++ b/Entity/Components/HealthComponent.gd
@@ -20,6 +20,12 @@ func _ready() -> void:
 	_set_health(max_health)
 
 
+## Used to emit the specific signal for this class [br]
+## Useful for classes that inherit from this one but want a different signal [br]
+func _emit_class_signal() -> void:
+	on_health_changed.emit(current_health)
+
+
 ## Deal damage to the entity [br]
 ## Use a negative damage value if you want to heal. [br]
 ## Caster can be null [br]
@@ -49,4 +55,4 @@ func _set_health(new_health: float) -> void:
 	if (new_health == current_health):
 		return
 	current_health = new_health
-	on_health_changed.emit(current_health)
+	_emit_class_signal()

--- a/Entity/Components/HealthComponent.gd
+++ b/Entity/Components/HealthComponent.gd
@@ -20,7 +20,6 @@ func _ready() -> void:
 	_set_health(max_health)
 
 
-
 ## Used to emit the specific signal for this class [br]
 ## Useful for classes that inherit from this one but want a different signal [br]
 func _emit_class_signal() -> void:

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -41,7 +41,10 @@ func _emit_class_signal() -> void:
 ## To be called on combat turn start [br]
 ## Add the stress generation to the current stress
 func on_turn_start() -> void:
-	pass
+	if stress_buildup:
+		current_stress += stress_generation
+		current_stress = clamp(current_stress, 0, max_stress)
+		_emit_class_signal()
 	
 
 ## Puts back the stress to the default value of max / 2

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -12,10 +12,6 @@ signal on_stress_changed(new_stress: int)
 ## The amount of stress the entity generates at the start of each turn
 @export var stress_generation: int = 5
 
-## Used to tell if an entity will add stress_generation to its current_stress on the start of the turn [br]
-## This is generally true, but is put to false whenever the entity is in a calm (state ie, stress reduced to 0)
-var stress_buildup: bool = true
-
 ## Know if an entity has been calmed already or not [br]
 ## This is used to not distribute XP twice for the same entity, even if it is calmed multiple times [br]
 var has_been_calmed: bool = false
@@ -41,7 +37,8 @@ func _emit_class_signal() -> void:
 ## To be called on combat turn start [br]
 ## Add the stress generation to the current stress
 func on_turn_start() -> void:
-	if stress_buildup:
+	# If the entity is not calmed, continue generating stress
+	if current_stress >= 1:
 		current_stress += stress_generation
 		current_stress = clamp(current_stress, 0, max_stress)
 		_emit_class_signal()
@@ -49,14 +46,17 @@ func on_turn_start() -> void:
 
 ## Puts back the stress to the default value of max / 2
 func _reset_stress() -> void:
-	pass
+	current_stress = floor(max_stress / 2.)
+	_emit_class_signal()
 
 
 ## Rewards XP for calming the entity, stops stress generation	
 func on_calmed() -> void:
 	pass
+	#TODO reward XP
 
 
 ## Makes the entity execute a powerful attack and resets the stress to its default value
 func on_overstress() -> void:
-	pass
+	# TODO make the powerful attack
+	_reset_stress()

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -18,6 +18,10 @@ var default_stress: int = floor(max_stress / 2.)
 ## This is used to not distribute XP twice for the same entity, even if it is calmed multiple times [br]
 var has_been_calmed: bool = false
 
+## Know if an entity has hit the overstress threshold [br]
+## This prevents the player from hitting the threshold during its turn and then calming the entity to avoid the attack [br]
+var has_hit_overstress: bool = false
+
 ## The current stress the entity has [br]
 ## Between 0 and [member StressComponent.max_stress]
 var current_stress: int
@@ -42,6 +46,12 @@ func modify_stress(amount: int, caster: Entity, is_sooth: bool = false) -> void:
 	# Allow caster to be null, but not the target.
 	# If caster is null, we assume that the modification came from an unknown source,
 	# so status won't calculate.
+	
+	# Prevent further stress modification if the entity has hit the overstress threshold
+	# This will go back to normal after the entity turn start
+	if has_hit_overstress:
+		return
+	
 	var new_stress: int
 
 	if amount <= 0.0:
@@ -60,6 +70,9 @@ func modify_stress(amount: int, caster: Entity, is_sooth: bool = false) -> void:
 		new_stress = clamp(current_stress + amount, 0, max_stress)
 	else:
 		new_stress = clamp(current_stress - amount, 0, max_stress)
+		
+	if new_stress == max_stress:
+		has_hit_overstress = true
 		
 	_set_stress(new_stress)
 
@@ -85,6 +98,7 @@ func on_turn_start() -> void:
 ## Puts back the stress to the default value of max / 2
 func _reset_stress() -> void:
 	current_stress = default_stress
+	has_hit_overstress = false
 	_emit_class_signal()
 
 

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -9,6 +9,8 @@ signal on_stress_changed(new_stress: int)
 ## The maximum stress the entity can have. This is a hard limit
 @export var max_stress: int = 100
 
+var default_stress: int = floor(max_stress / 2.)
+
 ## The amount of stress the entity generates at the start of each turn
 @export var stress_generation: int = 5
 
@@ -25,7 +27,7 @@ var current_stress: int
 ## This does not happen at game start for the player, as only enemies have a stress component [br]
 ## For enemies, this is called when the scene is instantiated (or more accurately, when each enemy is instanciated) [br]
 func _ready() -> void:
-	_set_stress(floor(max_stress / 2.))
+	_set_stress(default_stress)
 
 
 ## Used to emit the specific signal for this class [br]
@@ -82,7 +84,7 @@ func on_turn_start() -> void:
 
 ## Puts back the stress to the default value of max / 2
 func _reset_stress() -> void:
-	current_stress = floor(max_stress / 2.)
+	current_stress = default_stress
 	_emit_class_signal()
 
 

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -1,4 +1,4 @@
-class_name StressComponent extends HealthComponent
+class_name StressComponent extends EntityComponent
 ## Holds entities stress
 ##
 ## Allows entities to deal stress damage or sooth. Manages stress generation
@@ -18,20 +18,56 @@ var has_been_calmed: bool = false
 
 ## The current stress the entity has [br]
 ## Between 0 and [member StressComponent.max_stress]
-var current_stress: int = floor(max_stress / 2.)
+var current_stress: int
 
 ## @Override [br]
 ## Initialize the stress component, putting stress to max stress [br]
 ## This does not happen at game start for the player, as only enemies have a stress component [br]
 ## For enemies, this is called when the scene is instantiated (or more accurately, when each enemy is instanciated) [br]
 func _ready() -> void:
-	_set_health(max_stress)
+	_set_stress(floor(max_stress / 2.))
 
 
-## @Override [br]
 ## Used to emit the specific signal for this class [br]
 func _emit_class_signal() -> void:
 	on_stress_changed.emit(current_stress)
+	
+## Modify the stress of the entity [br]
+## Use the is_healing boolean if you want to heal. [br]
+## If the amount is negative, nothing will change. [br]
+## Caster can be null [br]
+func modify_stress(amount: int, caster: Entity, is_sooth: bool = false) -> void:
+	# Allow caster to be null, but not the target.
+	# If caster is null, we assume that the modification came from an unknown source,
+	# so status won't calculate.
+	var new_stress: int
+
+	if amount <= 0.0:
+		return
+	
+	assert(owner != null, "No owner was set. Please call init on the Entity.")
+	
+	var target: Entity = entity_owner # TODO change this name entity_owner to make it clearer
+	
+	# if the entity calls the function on itself then ignore the caster
+	if caster == target: 
+		caster = null
+
+	# apply modification to our stress
+	if is_sooth:
+		new_stress = clamp(current_stress + amount, 0, max_stress)
+	else:
+		new_stress = clamp(current_stress - amount, 0, max_stress)
+		
+	_set_stress(new_stress)
+
+
+## Set the stress of the entity [br]
+func _set_stress(new_stress: int) -> void:
+	if (new_stress == current_stress):
+		return
+	current_stress = new_stress
+	_emit_class_signal()
 	
 
 ## To be called on combat turn start [br]

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -16,6 +16,8 @@ var default_stress: int
 
 ## Know if an entity has been calmed already or not [br]
 ## This is used to not distribute XP twice for the same entity, even if it is calmed multiple times [br]
+## An enemy can be calmed multiple times if the player uses an effect that stresses the enemy, even
+## if the enemies don't generate stress naturally when they are soothed.
 var has_been_calmed: bool = false
 
 ## Know if an entity has hit the overstress threshold [br]

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -91,7 +91,7 @@ func _set_stress(new_stress: int) -> void:
 func on_turn_start() -> void:
 	# If the entity is not calmed, continue generating stress
 	if current_stress >= 1:
-		modify_stress(stress_generation, null)
+		modify_stress(stress_generation, null, true)
 
 func checked_reset_stress() -> void:
 	if has_hit_overstress:

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -1,0 +1,59 @@
+class_name StressComponent extends HealthComponent
+## Holds entities stress
+##
+## Allows entities to deal stress damage or sooth. Manages stress generation
+
+## Emit when stress is changed
+signal on_stress_changed(new_stress: int)
+
+## The maximum stress the entity can have. This is a hard limit
+@export var max_stress: int = 100
+
+## The amount of stress the entity generates at the start of each turn
+@export var stress_generation: int = 5
+
+## Used to tell if an entity will add stress_generation to its current_stress on the start of the turn [br]
+## This is generally true, but is put to false whenever the entity is in a calm (state ie, stress reduced to 0)
+var stress_buildup: bool = true
+
+## Know if an entity has been calmed already or not [br]
+## This is used to not distribute XP twice for the same entity, even if it is calmed multiple times [br]
+var has_been_calmed: bool = false
+
+## The current stress the entity has [br]
+## Between 0 and [member StressComponent.max_stress]
+var current_stress: int = floor(max_stress / 2.)
+
+## @Override [br]
+## Initialize the stress component, putting stress to max stress [br]
+## This does not happen at game start for the player, as only enemies have a stress component [br]
+## For enemies, this is called when the scene is instantiated (or more accurately, when each enemy is instanciated) [br]
+func _ready() -> void:
+	_set_health(max_stress)
+
+
+## @Override [br]
+## Used to emit the specific signal for this class [br]
+func _emit_class_signal() -> void:
+	on_stress_changed.emit(current_stress)
+	
+
+## To be called on combat turn start [br]
+## Add the stress generation to the current stress
+func on_turn_start() -> void:
+	pass
+	
+
+## Puts back the stress to the default value of max / 2
+func _reset_stress() -> void:
+	pass
+
+
+## Rewards XP for calming the entity, stops stress generation	
+func on_calmed() -> void:
+	pass
+
+
+## Makes the entity execute a powerful attack and resets the stress to its default value
+func on_overstress() -> void:
+	pass

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -90,9 +90,7 @@ func _set_stress(new_stress: int) -> void:
 func on_turn_start() -> void:
 	# If the entity is not calmed, continue generating stress
 	if current_stress >= 1:
-		current_stress += stress_generation
-		current_stress = clamp(current_stress, 0, max_stress)
-		_emit_class_signal()
+		modify_stress(stress_generation, null)
 	
 
 ## Puts back the stress to the default value of max / 2

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -40,7 +40,7 @@ func _emit_class_signal() -> void:
 	on_stress_changed.emit(current_stress)
 	
 ## Modify the stress of the entity [br]
-## Use the is_healing boolean if you want to heal. [br]
+## Use the is_sooth boolean if you want to sooth. [br]
 ## If the amount is negative, nothing will change. [br]
 ## Caster can be null [br]
 func modify_stress(amount: int, caster: Entity, is_sooth: bool = false) -> void:

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -68,9 +68,9 @@ func modify_stress(amount: int, caster: Entity, is_sooth: bool = false) -> void:
 
 	# apply modification to our stress
 	if is_sooth:
-		new_stress = clamp(current_stress + amount, 0, max_stress)
-	else:
 		new_stress = clamp(current_stress - amount, 0, max_stress)
+	else:
+		new_stress = clamp(current_stress + amount, 0, max_stress)
 		
 	if new_stress == max_stress:
 		has_hit_overstress = true
@@ -91,7 +91,7 @@ func _set_stress(new_stress: int) -> void:
 func on_turn_start() -> void:
 	# If the entity is not calmed, continue generating stress
 	if current_stress >= 1:
-		modify_stress(stress_generation, null, true)
+		modify_stress(stress_generation, null)
 
 func checked_reset_stress() -> void:
 	if has_hit_overstress:

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -113,7 +113,7 @@ func on_calmed() -> void:
 
 
 ## Makes the entity execute a powerful attack
-func on_overstress() -> CardBase:
+static func on_overstress() -> CardBase:
 	var attack: CardBase = CardBase.new()
 	var basic_effect_data: EffectData = EffectData.new( EffectDamage.new(),
 														null,

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -9,7 +9,7 @@ signal on_stress_changed(new_stress: int)
 ## The maximum stress the entity can have. This is a hard limit
 @export var max_stress: int = 100
 
-var default_stress: int = floor(max_stress / 2.)
+var default_stress: int
 
 ## The amount of stress the entity generates at the start of each turn
 @export var stress_generation: int = 5
@@ -31,6 +31,7 @@ var current_stress: int
 ## This does not happen at game start for the player, as only enemies have a stress component [br]
 ## For enemies, this is called when the scene is instantiated (or more accurately, when each enemy is instanciated) [br]
 func _ready() -> void:
+	default_stress = floor(max_stress / 2.)
 	_set_stress(default_stress)
 
 

--- a/Entity/Components/StressComponent.gd
+++ b/Entity/Components/StressComponent.gd
@@ -91,7 +91,10 @@ func on_turn_start() -> void:
 	# If the entity is not calmed, continue generating stress
 	if current_stress >= 1:
 		modify_stress(stress_generation, null)
-	
+
+func checked_reset_stress() -> void:
+	if has_hit_overstress:
+		_reset_stress()
 
 ## Puts back the stress to the default value of max / 2
 func _reset_stress() -> void:
@@ -106,7 +109,13 @@ func on_calmed() -> void:
 	#TODO reward XP
 
 
-## Makes the entity execute a powerful attack and resets the stress to its default value
-func on_overstress() -> void:
-	# TODO make the powerful attack
-	_reset_stress()
+## Makes the entity execute a powerful attack
+func on_overstress() -> CardBase:
+	var attack: CardBase = CardBase.new()
+	var basic_effect_data: EffectData = EffectData.new( EffectDamage.new(),
+														null,
+														5,
+														TargetingBase.new())
+	attack.card_effects_data.append(basic_effect_data)
+	attack.application_type = GlobalEnums.ApplicationType.FRIENDLY_ONLY
+	return attack

--- a/Entity/Enemy/Enemy.gd
+++ b/Entity/Enemy/Enemy.gd
@@ -8,6 +8,7 @@ class_name Enemy
 func _ready() -> void:
 	super()
 	PhaseManager.on_phase_changed.connect(_on_phase_changed)
+	get_stress_component().init_entity_component(self)
 
 
 ## Only allow the player to interact with enemies when it's the player turn
@@ -18,3 +19,9 @@ func _on_phase_changed(new_phase: GlobalEnums.Phase, _old_phase: GlobalEnums.Pha
 ## Not in [Entity] as this is specific to enemies
 func get_behavior_component() -> BehaviorComponent:
 	return Helpers.get_first_child_node_of_type(self, BehaviorComponent) as BehaviorComponent
+	
+
+## Used to get the stress level of enemies [br]
+## Not in [Entity] as this is specific to enemies
+func get_stress_component() -> StressComponent:
+	return Helpers.get_first_child_node_of_type(self, StressComponent) as StressComponent

--- a/Entity/Enemy/Enemy.tscn
+++ b/Entity/Enemy/Enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://bpgsmfprnm2kk"]
+[gd_scene load_steps=14 format=3 uid="uid://bpgsmfprnm2kk"]
 
 [ext_resource type="Script" path="res://Entity/Enemy/Enemy.gd" id="1_ya6nf"]
 [ext_resource type="Script" path="res://Entity/Components/StatComponent.gd" id="2_twygh"]
@@ -10,6 +10,7 @@
 [ext_resource type="Script" path="res://Entity/Components/PartyComponent.gd" id="8_yr066"]
 [ext_resource type="Script" path="res://Entity/Components/BehaviorComponent.gd" id="9_kvor6"]
 [ext_resource type="Resource" uid="uid://bsrdu33ukb1ym" path="res://Cards/Resource/Card_EnemyAttack.tres" id="10_l5325"]
+[ext_resource type="Script" path="res://Entity/Components/StressComponent.gd" id="11_qf75g"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_b8bva"]
 size = Vector2(104, 93)
@@ -58,6 +59,9 @@ script = ExtResource("8_yr066")
 [node name="BehaviorComponent" type="Node" parent="."]
 script = ExtResource("9_kvor6")
 attack = ExtResource("10_l5325")
+
+[node name="StressComponent" type="Node" parent="."]
+script = ExtResource("11_qf75g")
 
 [connection signal="input_event" from="Area2D" to="ClickHandler" method="_on_input_event"]
 [connection signal="mouse_entered" from="Area2D" to="ClickHandler" method="_on_mouse_entered"]

--- a/Entity/Enemy/Enemy.tscn
+++ b/Entity/Enemy/Enemy.tscn
@@ -50,22 +50,24 @@ position = Vector2(5, 2.5)
 shape = SubResource("RectangleShape2D_b8bva")
 
 [node name="HealthLabel" type="Label" parent="." node_paths=PackedStringArray("health_component")]
-offset_left = -48.0
-offset_top = -84.0
-offset_right = 52.0
-offset_bottom = -45.0
-text = "100/100"
+offset_left = -57.0
+offset_top = -83.0
+offset_right = 57.0
+offset_bottom = -44.0
+text = "100 / 100"
 label_settings = SubResource("LabelSettings_urr12")
+horizontal_alignment = 1
 script = ExtResource("7_tofxs")
 health_component = NodePath("../HealthComponent")
 
 [node name="StressLabel" type="Label" parent="." node_paths=PackedStringArray("stress_component")]
-offset_left = -48.0
-offset_top = -109.005
-offset_right = 52.0
-offset_bottom = -70.005
-text = "100/100"
+offset_left = -57.0
+offset_top = -109.0
+offset_right = 57.0
+offset_bottom = -70.0
+text = "100 / 100"
 label_settings = SubResource("LabelSettings_3exsi")
+horizontal_alignment = 1
 script = ExtResource("8_w2u2o")
 stress_component = NodePath("../StressComponent")
 
@@ -78,8 +80,8 @@ attack = ExtResource("10_l5325")
 
 [node name="StressComponent" type="Node" parent="."]
 script = ExtResource("11_qf75g")
-max_stress = 75
-stress_generation = 3
+max_stress = 80
+stress_generation = 20
 
 [connection signal="input_event" from="Area2D" to="ClickHandler" method="_on_input_event"]
 [connection signal="mouse_entered" from="Area2D" to="ClickHandler" method="_on_mouse_entered"]

--- a/Entity/Enemy/Enemy.tscn
+++ b/Entity/Enemy/Enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://bpgsmfprnm2kk"]
+[gd_scene load_steps=16 format=3 uid="uid://bpgsmfprnm2kk"]
 
 [ext_resource type="Script" path="res://Entity/Enemy/Enemy.gd" id="1_ya6nf"]
 [ext_resource type="Script" path="res://Entity/Components/StatComponent.gd" id="2_twygh"]
@@ -7,6 +7,7 @@
 [ext_resource type="Texture2D" uid="uid://bu626jwgp3r5x" path="res://Art/Enemies/green_sapling-default.png" id="5_dxya8"]
 [ext_resource type="Script" path="res://Input/ClickHandler.gd" id="6_m32ri"]
 [ext_resource type="Script" path="res://UI/HealthLabel.gd" id="7_tofxs"]
+[ext_resource type="Script" path="res://UI/StressLabel.gd" id="8_w2u2o"]
 [ext_resource type="Script" path="res://Entity/Components/PartyComponent.gd" id="8_yr066"]
 [ext_resource type="Script" path="res://Entity/Components/BehaviorComponent.gd" id="9_kvor6"]
 [ext_resource type="Resource" uid="uid://bsrdu33ukb1ym" path="res://Cards/Resource/Card_EnemyAttack.tres" id="10_l5325"]
@@ -58,15 +59,15 @@ label_settings = SubResource("LabelSettings_urr12")
 script = ExtResource("7_tofxs")
 health_component = NodePath("../HealthComponent")
 
-[node name="StressLabel" type="Label" parent="." node_paths=PackedStringArray("health_component")]
+[node name="StressLabel" type="Label" parent="." node_paths=PackedStringArray("stress_component")]
 offset_left = -48.0
 offset_top = -109.005
 offset_right = 52.0
 offset_bottom = -70.005
 text = "100/100"
 label_settings = SubResource("LabelSettings_3exsi")
-script = ExtResource("7_tofxs")
-health_component = NodePath("../HealthComponent")
+script = ExtResource("8_w2u2o")
+stress_component = NodePath("../StressComponent")
 
 [node name="PartyComponent" type="Node" parent="."]
 script = ExtResource("8_yr066")
@@ -77,6 +78,8 @@ attack = ExtResource("10_l5325")
 
 [node name="StressComponent" type="Node" parent="."]
 script = ExtResource("11_qf75g")
+max_stress = 75
+stress_generation = 3
 
 [connection signal="input_event" from="Area2D" to="ClickHandler" method="_on_input_event"]
 [connection signal="mouse_entered" from="Area2D" to="ClickHandler" method="_on_mouse_entered"]

--- a/Entity/Enemy/Enemy.tscn
+++ b/Entity/Enemy/Enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://bpgsmfprnm2kk"]
+[gd_scene load_steps=15 format=3 uid="uid://bpgsmfprnm2kk"]
 
 [ext_resource type="Script" path="res://Entity/Enemy/Enemy.gd" id="1_ya6nf"]
 [ext_resource type="Script" path="res://Entity/Components/StatComponent.gd" id="2_twygh"]
@@ -18,7 +18,12 @@ size = Vector2(104, 93)
 [sub_resource type="LabelSettings" id="LabelSettings_urr12"]
 font_size = 26
 
+[sub_resource type="LabelSettings" id="LabelSettings_3exsi"]
+font_size = 26
+font_color = Color(0.435294, 0.67451, 0.815686, 1)
+
 [node name="Enemy" type="Node2D"]
+position = Vector2(0, 50)
 script = ExtResource("1_ya6nf")
 
 [node name="StatComponent" type="Node" parent="."]
@@ -50,6 +55,16 @@ offset_right = 52.0
 offset_bottom = -45.0
 text = "100/100"
 label_settings = SubResource("LabelSettings_urr12")
+script = ExtResource("7_tofxs")
+health_component = NodePath("../HealthComponent")
+
+[node name="StressLabel" type="Label" parent="." node_paths=PackedStringArray("health_component")]
+offset_left = -48.0
+offset_top = -109.005
+offset_right = 52.0
+offset_bottom = -70.005
+text = "100/100"
+label_settings = SubResource("LabelSettings_3exsi")
 script = ExtResource("7_tofxs")
 health_component = NodePath("../HealthComponent")
 

--- a/Entity/Enemy/Enemy_SaplingGreen.tscn
+++ b/Entity/Enemy/Enemy_SaplingGreen.tscn
@@ -4,8 +4,8 @@
 
 [node name="Enemy" instance=ExtResource("1_klc51")]
 
-[node name="HealthLabel" parent="." index="6"]
-horizontal_alignment = 1
-
 [node name="StressLabel" parent="." index="7"]
 text = "10/20"
+
+[node name="StressComponent" parent="." index="10"]
+stress_generation = 5

--- a/Entity/Enemy/Enemy_SaplingGreen.tscn
+++ b/Entity/Enemy/Enemy_SaplingGreen.tscn
@@ -3,3 +3,9 @@
 [ext_resource type="PackedScene" uid="uid://bpgsmfprnm2kk" path="res://Entity/Enemy/Enemy.tscn" id="1_klc51"]
 
 [node name="Enemy" instance=ExtResource("1_klc51")]
+
+[node name="HealthLabel" parent="." index="6"]
+horizontal_alignment = 1
+
+[node name="StressLabel" parent="." index="7"]
+text = "10/20"

--- a/Entity/Enemy/Enemy_SaplingRed.tscn
+++ b/Entity/Enemy/Enemy_SaplingRed.tscn
@@ -10,3 +10,7 @@ max_health = 50.0
 
 [node name="Sprite2D" parent="." index="3"]
 texture = ExtResource("2_qypjd")
+
+[node name="StressComponent" parent="." index="10"]
+max_stress = 30
+stress_generation = 3

--- a/Entity/Enemy/Enemy_SaplingRed.tscn
+++ b/Entity/Enemy/Enemy_SaplingRed.tscn
@@ -16,3 +16,4 @@ text = "40/80"
 
 [node name="StressComponent" parent="." index="10"]
 max_stress = 30
+stress_generation = 3

--- a/Entity/Enemy/Enemy_SaplingRed.tscn
+++ b/Entity/Enemy/Enemy_SaplingRed.tscn
@@ -11,6 +11,8 @@ max_health = 50.0
 [node name="Sprite2D" parent="." index="3"]
 texture = ExtResource("2_qypjd")
 
+[node name="StressLabel" parent="." index="7"]
+text = "40/80"
+
 [node name="StressComponent" parent="." index="10"]
 max_stress = 30
-stress_generation = 3

--- a/Entity/Entity.gd
+++ b/Entity/Entity.gd
@@ -10,7 +10,6 @@ func _ready() -> void:
 	get_health_component().init_entity_component(self)
 	get_party_component().init_entity_component(self)
 	get_stat_component().init_entity_component(self)
-	get_stress_component().init_entity_component(self)
 
 
 func get_status_component() -> StatusComponent:
@@ -31,8 +30,4 @@ func get_party_component() -> PartyComponent:
 
 func get_click_handler() -> ClickHandler:
 	return Helpers.get_first_child_node_of_type(self, ClickHandler) as ClickHandler
-	
-
-func get_stress_component() -> StressComponent:
-	return Helpers.get_first_child_node_of_type(self, StressComponent) as StressComponent
 

--- a/Entity/Entity.gd
+++ b/Entity/Entity.gd
@@ -10,6 +10,7 @@ func _ready() -> void:
 	get_health_component().init_entity_component(self)
 	get_party_component().init_entity_component(self)
 	get_stat_component().init_entity_component(self)
+	get_stress_component().init_entity_component(self)
 
 
 func get_status_component() -> StatusComponent:
@@ -30,4 +31,8 @@ func get_party_component() -> PartyComponent:
 
 func get_click_handler() -> ClickHandler:
 	return Helpers.get_first_child_node_of_type(self, ClickHandler) as ClickHandler
+	
+
+func get_stress_component() -> StressComponent:
+	return Helpers.get_first_child_node_of_type(self, StressComponent) as StressComponent
 

--- a/Global/Global_Enums.gd
+++ b/Global/Global_Enums.gd
@@ -72,7 +72,9 @@ enum EntityStatDictType {
 ## A value of 1 on the DAMAGE of DEFENSE means you take one less damage [br]
 enum PossibleModifierNames {
 	DAMAGE,
+	STRESS,
 	HEAL,
+	SOOTH,
 	POISON,
 	DRAW,
 	CARD_REWARD_NUMBER

--- a/Managers/MapManager.gd
+++ b/Managers/MapManager.gd
@@ -40,7 +40,7 @@ func create_map(map_floors_width: Array[int] = map_width_array) -> MapBase:
 		var _floor_width : int = map_floors_width[index_height]
 		# ! only works if the size of the floor is odd
 
-		var _padding_size : int = (_max_floor_size - _floor_width)/2
+		var _padding_size : int = floor((_max_floor_size - _floor_width)/2.)
 		
 		var _padding:Array = []
 		_padding.resize(_padding_size)

--- a/Status/Buffs/Buff_Sooth.gd
+++ b/Status/Buffs/Buff_Sooth.gd
@@ -1,0 +1,13 @@
+class_name Buff_Sooth extends BuffBase
+## Increases the target's ability to soothe others
+
+## @Override
+func _init() -> void:
+	is_stat_modification = true
+	is_on_apply = true
+	modifier_name = GlobalEnums.PossibleModifierNames.SOOTH
+	
+## @Override
+func init_status(in_caster: Entity, in_target: Entity) -> void:
+	super.init_status(in_caster, in_target)
+	EntityStatDictType = GlobalEnums.EntityStatDictType.OFFENSE

--- a/Status/Debuffs/Debuff_Sooth.gd
+++ b/Status/Debuffs/Debuff_Sooth.gd
@@ -1,0 +1,13 @@
+class_name Debuff_Sooth extends DebuffBase
+## Reduce the target's ability to soothe others
+
+## @Override
+func _init() -> void:
+	is_stat_modification = true
+	is_on_apply = true
+	modifier_name = GlobalEnums.PossibleModifierNames.SOOTH
+	
+## @Override
+func init_status(in_caster: Entity, _in_target: Entity) -> void:
+	super.init_status(in_caster, in_caster)
+	EntityStatDictType = GlobalEnums.EntityStatDictType.OFFENSE

--- a/Tests/TestBase.gd
+++ b/Tests/TestBase.gd
@@ -31,6 +31,10 @@ var _player_stat_component: StatComponent = null
 var _enemy_stat_component: StatComponent = null
 ## Enemy 2 stat component
 var _enemy_2_stat_component: StatComponent = null
+## Enemy stress component
+var _enemy_stress_component: StressComponent = null
+## Enemy 2 stress component
+var _enemy_2_stress_component: StressComponent = null
 ## Player status component
 var _player_status_component: StatusComponent = null
 ## Enemy status component
@@ -67,6 +71,8 @@ func before_each() -> void:
 	_player_stat_component = _player.get_stat_component()
 	_enemy_stat_component = _enemy.get_stat_component()
 	_enemy_2_stat_component = _enemy_2.get_stat_component()
+	_enemy_stress_component = _enemy.get_stress_component()
+	_enemy_2_stress_component = _enemy_2.get_stress_component()
 	_enemy_2_health_component = _enemy_2.get_health_component()
 	_player_status_component = _player.get_status_component()
 	_enemy_status_component = _enemy.get_status_component()

--- a/Tests/test_stats.gd
+++ b/Tests/test_stats.gd
@@ -3,7 +3,7 @@ extends TestBase
 
 
 func test_possible_modifier_size() -> void:
-	var expected_size: int = 5
+	var expected_size: int = 7
 	var actual_size: int = GlobalEnums.PossibleModifierNames.size()
 	assert_eq(actual_size, expected_size, "Expected %s possible modifiers but got %s instead" % [expected_size, actual_size])
 

--- a/Tests/test_stress.gd
+++ b/Tests/test_stress.gd
@@ -1,0 +1,43 @@
+extends TestBase
+## Test the stress mechanic
+
+func test_stress_generation() -> void:
+	var previous_stress: int = _enemy_stress_component.current_stress
+	var stress_generation: int = 5
+	_enemy_stress_component.stress_generation = stress_generation
+	_enemy_stress_component.on_turn_start()
+	assert_eq(_enemy_stress_component.current_stress - previous_stress, stress_generation)
+
+	
+func test_stress_card() -> void:
+	var previous_stress: int = _enemy_stress_component.current_stress
+	var card_stress: CardBase = load("res://Cards/Resource/Card_Stress_Damage.tres")
+	card_stress.on_card_play(_player, _enemy)
+	assert_eq(_enemy_stress_component.current_stress, previous_stress + 10)
+	
+	
+func test_sooth_card() -> void:
+	var previous_stress: int = _enemy_stress_component.current_stress
+	var card_sooth: CardBase = load("res://Cards/Resource/Card_sooth.tres")
+	card_sooth.on_card_play(_player, _enemy)
+	assert_eq(_enemy_stress_component.current_stress, previous_stress - 10)
+	
+	
+func test_sooth_buff() -> void:
+	var previous_stress: int = _enemy_stress_component.current_stress
+	var buff_sooth: CardBase = load("res://Cards/Resource/Card_buff_sooth.tres")
+	StatModifiers.ready_card_modifier(buff_sooth)
+	buff_sooth.on_card_play(_player, _player)
+	var card_sooth: CardBase = load("res://Cards/Resource/Card_sooth.tres")
+	card_sooth.on_card_play(_player, _enemy)
+	assert_eq(_enemy_stress_component.current_stress, previous_stress - 11)
+	
+	
+func test_sooth_debuff() -> void:
+	var previous_stress: int = _enemy_stress_component.current_stress
+	var debuff_sooth: CardBase = load("res://Cards/Resource/Card_debuff_sooth.tres")
+	StatModifiers.ready_card_modifier(debuff_sooth)
+	debuff_sooth.on_card_play(_player, _player)
+	var card_sooth: CardBase = load("res://Cards/Resource/Card_sooth.tres")
+	card_sooth.on_card_play(_player, _enemy)
+	assert_eq(_enemy_stress_component.current_stress, previous_stress - 9)

--- a/UI/StressLabel.gd
+++ b/UI/StressLabel.gd
@@ -10,5 +10,5 @@ func _ready() -> void:
 	_set_stress(stress_component.current_stress)
 
 
-func _set_stress(_new_stress: float) -> void:
-	text = str(stress_component.current_stress) + " / " + str(stress_component.max_stress)
+func _set_stress(new_stress: float) -> void:
+	text = str(new_stress) + " / " + str(stress_component.max_stress)

--- a/UI/StressLabel.gd
+++ b/UI/StressLabel.gd
@@ -1,0 +1,14 @@
+extends Label
+## Simple setter that pulls from the stress component.
+
+
+@export var stress_component: StressComponent = null
+
+
+func _ready() -> void:
+	stress_component.on_stress_changed.connect(_set_stress)
+	_set_stress(stress_component.current_stress)
+
+
+func _set_stress(_new_stress: float) -> void:
+	text = str(stress_component.current_stress) + " / " + str(stress_component.max_stress)

--- a/UI/StressLabel.gd
+++ b/UI/StressLabel.gd
@@ -11,4 +11,7 @@ func _ready() -> void:
 
 
 func _set_stress(new_stress: float) -> void:
-	text = str(new_stress) + " / " + str(stress_component.max_stress)
+	if new_stress >= 1:
+		text = str(new_stress) + " / " + str(stress_component.max_stress)
+	else:
+		text = "Soothed"


### PR DESCRIPTION
# Description

Well not really a bar yet, but we are getting there. Implements the stress mechanic (not the XP and global XP bar yet).

## Related issue(s)

#55 (doesn't close it yet as it needs the XP to be finished)

## List of changes

- Add a `StressComponent` (not child of `HealthComponent` as was initially suggested in the issue)
- Add a label above enemies to show their current stress
- Add a powerful attack when Stress is at max
- Add some buff / debuff
- Add related cards
- Add tests

## Tests

Test basic things, stress, sooth, buff, debuff and stress generation

## Additional notes

The XP needs to be implemented to complete this. I did not implement a buff / debuff on stress generation (since I'm not even sure we would need it).