### PR TITLE
Fix status are carried between fights

### DIFF
--- a/Entity/Components/StatusComponent.gd
+++ b/Entity/Components/StatusComponent.gd
@@ -11,6 +11,10 @@ class_name StatusComponent
 var current_status: Array[StatusBase] = []
 
 
+func _ready() -> void:
+	PhaseManager.on_event_win.connect(remove_all_status)
+
+
 ## Add a new status to the entity [br]
 ## The status caster is the one applying the status. [br]
 ## If the target entity already has the status, the duration of the new status is added to the existing one. [br]

--- a/addons/gut/source_code_pro.fnt.import
+++ b/addons/gut/source_code_pro.fnt.import
@@ -14,3 +14,4 @@ dest_files=["res://.godot/imported/source_code_pro.fnt-042fb383b3c7b4c19e67c852f
 
 fallbacks=[]
 compress=true
+scaling_mode=2

--- a/addons/gut/source_code_pro.fnt.import
+++ b/addons/gut/source_code_pro.fnt.import
@@ -14,4 +14,3 @@ dest_files=["res://.godot/imported/source_code_pro.fnt-042fb383b3c7b4c19e67c852f
 
 fallbacks=[]
 compress=true
-scaling_mode=2


### PR DESCRIPTION
# Description

Fix status are carried between fights

## Related issue(s)

[If your pull request is in link with an existing issue, please put a link to the issue here.](https://github.com/Saplings-Projects/1M_sub/issues/104)

## List of changes

Add a _ready() function in StatusComponent that connect its remove_all_status() function to the PhaseManager.on_event_win signal

## Tests

If you wrote test scripts to use with GUT, provide a summary of those tests here.

## Additional notes

If you have anything more to add.
