### PR TITLE
Skip event button self delete

### DIFF
--- a/#Scenes/Events/dialogue/0.tscn
+++ b/#Scenes/Events/dialogue/0.tscn
@@ -251,10 +251,10 @@ autowrap_mode = 2
 
 [node name="SkipEventButton" type="Button" parent="."]
 offset_left = 64.0
-offset_top = 987.0
-offset_right = 111.0
+offset_top = 983.0
+offset_right = 208.0
 offset_bottom = 1021.0
-text = "Skip
+text = "Skip this event
 "
 script = ExtResource("6_p63fb")
 

--- a/#Scenes/Events/dialogue/0.tscn
+++ b/#Scenes/Events/dialogue/0.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=11 format=3 uid="uid://bvgmldqlys8fr"]
+[gd_scene load_steps=12 format=3 uid="uid://bvgmldqlys8fr"]
 
 [ext_resource type="Script" path="res://Dialog/EventDialogueWindow.gd" id="1_y8x42"]
 [ext_resource type="Texture2D" uid="uid://ube4dr03nn7e" path="res://Art/NPC/example-default.png" id="2_vyxv5"]
 [ext_resource type="PackedScene" uid="uid://ckvgyvclnwggo" path="res://addons/dialogue_manager/dialogue_label.tscn" id="3_sq1s4"]
 [ext_resource type="Script" path="res://addons/dialogue_manager/dialogue_reponses_menu.gd" id="4_2ecgp"]
 [ext_resource type="PackedScene" uid="uid://bam77cwf4emyr" path="res://#Scenes/TopBarOverlay.tscn" id="5_wppna"]
+[ext_resource type="Script" path="res://#Scenes/Events/skipEventButton.gd" id="6_p63fb"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_spyqn"]
 bg_color = Color(0, 0, 0, 1)
@@ -247,6 +248,15 @@ rotation = -0.251327
 theme_override_colors/default_color = Color(0, 0, 0, 1)
 fit_content = true
 autowrap_mode = 2
+
+[node name="SkipEventButton" type="Button" parent="."]
+offset_left = 64.0
+offset_top = 987.0
+offset_right = 111.0
+offset_bottom = 1021.0
+text = "Skip
+"
+script = ExtResource("6_p63fb")
 
 [connection signal="gui_input" from="Balloon" to="." method="_on_balloon_gui_input"]
 [connection signal="response_selected" from="Balloon/Panel/VBoxContainer/Responses/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]

--- a/#Scenes/Events/heal/0.tscn
+++ b/#Scenes/Events/heal/0.tscn
@@ -38,5 +38,3 @@ grow_vertical = 0
 theme_override_font_sizes/font_size = 26
 text = "Skip this event"
 script = ExtResource("2_1m5v4")
-
-[connection signal="pressed" from="SkipEventButton" to="SkipEventButton" method="_on_pressed"]

--- a/#Scenes/Events/mob/0.tscn
+++ b/#Scenes/Events/mob/0.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://sg1wi7uqvv25"]
+[gd_scene load_steps=16 format=3 uid="uid://sg1wi7uqvv25"]
 
 [ext_resource type="Script" path="res://#Scenes/SceneScripts/TestingScene.gd" id="1_nmgwp"]
 [ext_resource type="PackedScene" uid="uid://bcpmrmofcilbn" path="res://Core/Battler.tscn" id="2_e6pjn"]
@@ -14,6 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://d4muqvs3etnr8" path="res://Art/Card_layout/discard_pile.png" id="12_0nlrw"]
 [ext_resource type="Script" path="res://UI/DiscardPileUISetter.gd" id="13_8nsar"]
 [ext_resource type="PackedScene" uid="uid://bam77cwf4emyr" path="res://#Scenes/TopBarOverlay.tscn" id="14_os5i4"]
+[ext_resource type="Script" path="res://#Scenes/Events/skipEventButton.gd" id="15_ucp4y"]
 
 [node name="TestingScene" type="Node2D"]
 script = ExtResource("1_nmgwp")
@@ -174,6 +175,14 @@ main menu"
 
 [node name="TopBarOverlay" parent="CanvasLayer/UIControl" instance=ExtResource("14_os5i4")]
 layout_mode = 1
+
+[node name="SkipEventButton" type="Button" parent="CanvasLayer/UIControl"]
+offset_left = 1676.0
+offset_top = 30.0
+offset_right = 1717.0
+offset_bottom = 61.0
+text = "Skip"
+script = ExtResource("15_ucp4y")
 
 [connection signal="pressed" from="CanvasLayer/UIControl/EndTurnButton" to="CanvasLayer/UIControl/EndTurnButton" method="_on_pressed"]
 [connection signal="pressed" from="CanvasLayer/UIControl/back_to_main_menu" to="CanvasLayer/UIControl" method="_on_back_to_main_menu_pressed"]

--- a/#Scenes/Events/mob/0.tscn
+++ b/#Scenes/Events/mob/0.tscn
@@ -177,11 +177,12 @@ main menu"
 layout_mode = 1
 
 [node name="SkipEventButton" type="Button" parent="CanvasLayer/UIControl"]
-offset_left = 1676.0
+layout_mode = 0
+offset_left = 1597.0
 offset_top = 30.0
-offset_right = 1717.0
-offset_bottom = 61.0
-text = "Skip"
+offset_right = 1741.0
+offset_bottom = 68.0
+text = "Skip this event"
 script = ExtResource("15_ucp4y")
 
 [connection signal="pressed" from="CanvasLayer/UIControl/EndTurnButton" to="CanvasLayer/UIControl/EndTurnButton" method="_on_pressed"]

--- a/#Scenes/Events/shop/0.tscn
+++ b/#Scenes/Events/shop/0.tscn
@@ -38,5 +38,3 @@ grow_vertical = 0
 theme_override_font_sizes/font_size = 26
 text = "Skip this event"
 script = ExtResource("2_owx5q")
-
-[connection signal="pressed" from="SkipEventButton" to="SkipEventButton" method="_on_pressed"]

--- a/#Scenes/Events/skipEventButton.gd
+++ b/#Scenes/Events/skipEventButton.gd
@@ -1,11 +1,13 @@
 extends Button
+class_name SkipEventButton
 ## Code for the button that allows the player to skip the event in placeholder scenes
 
 ## Enable / Disable the button based on the debug variable DEBUG_SKIP_EVENT
 func _ready() -> void:
-	self.disabled = not DebugVar.DEBUG_SKIP_EVENT
+	if not DebugVar.DEBUG_SKIP_EVENT:
+		queue_free()
 	
 
 ## Activate the event ending function when the button is pressed
-func _on_pressed() -> void:
+func _pressed() -> void:
 	PlayerManager.player_room.room_event.on_event_ended()


### PR DESCRIPTION
# Description

Skip event button self delete

## Related issue(s)

#97

## List of changes

Skip event button will delete itself if DEBUG_SKIP_EVENT is false. SkipEventButton is now available in the node selection menu. SkipEventButton doesnt need to connect its pressed() signal anymore since the _pressed() function is called directly.

Also add SkipEventButton to mob and dialogue scene, altho dialogue scene still have bug that prevent any button other than the dialogue button from being pressed.

## Tests

If you wrote test scripts to use with GUT, provide a summary of those tests here.

## Additional notes

If you have anything more to add.
