### PR TITLE
A new way to change phase

### DIFF
--- a/#Scenes/Events/mob/0.tscn
+++ b/#Scenes/Events/mob/0.tscn
@@ -14,7 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://d4muqvs3etnr8" path="res://Art/Card_layout/discard_pile.png" id="12_0nlrw"]
 [ext_resource type="Script" path="res://UI/DiscardPileUISetter.gd" id="13_8nsar"]
 [ext_resource type="PackedScene" uid="uid://bam77cwf4emyr" path="res://#Scenes/TopBarOverlay.tscn" id="14_os5i4"]
-[ext_resource type="PackedScene" path="res://#Scenes/xp_bar.tscn" id="15_r7cr8"]
+[ext_resource type="PackedScene" uid="uid://ruwidm3egyrx" path="res://#Scenes/xp_bar.tscn" id="15_r7cr8"]
 
 [node name="TestingScene" type="Node2D"]
 script = ExtResource("1_nmgwp")

--- a/Cards/CardContainer.gd
+++ b/Cards/CardContainer.gd
@@ -47,7 +47,7 @@ var _cards_queued_for_discard: Array[CardWorld] = []
 var _discard_timer: SceneTreeTimer = null
 
 func _ready() -> void:
-	PhaseManager.on_phase_changed.connect(_on_phase_changed)
+	PhaseManager.on_combat_phase_changed.connect(_on_phase_changed)
 	CardManager.on_deck_initialized.connect(_init_default_draw_pile)
 	CardManager.set_card_container(self)
 	CardManager.on_card_action_finished.connect(finish_active_card_action.unbind(1))
@@ -294,14 +294,14 @@ func _handle_discard_queue() -> void:
 	
 	if _cards_queued_for_discard.size() > 0:
 		_handle_discard_queue()
-	elif PhaseManager.current_phase == GlobalEnums.Phase.PLAYER_FINISHING:
+	elif PhaseManager.current_combat_phase == GlobalEnums.CombatPhase.PLAYER_FINISHING:
 		on_finished_discarding_hand.emit()
 
 
-func _on_phase_changed(new_phase: GlobalEnums.Phase, _old_phase: GlobalEnums.Phase) -> void:
-	if new_phase == GlobalEnums.Phase.PLAYER_ATTACKING:
+func _on_phase_changed(new_phase: GlobalEnums.CombatPhase, _old_phase: GlobalEnums.CombatPhase) -> void:
+	if new_phase == GlobalEnums.CombatPhase.PLAYER_ATTACKING:
 		deal_to_starting_hand_size()
-	if new_phase == GlobalEnums.Phase.PLAYER_FINISHING:
+	if new_phase == GlobalEnums.CombatPhase.PLAYER_FINISHING:
 		if (cards_in_hand.size() == 0):
 			on_finished_discarding_hand.emit()
 		else:

--- a/Cards/CardWorld.gd
+++ b/Cards/CardWorld.gd
@@ -10,7 +10,7 @@ var card_data: CardBase = null
 var card_cast_type : GlobalEnums.CardCastType
 
 func _ready() -> void:
-	PhaseManager.on_phase_changed.connect(_on_phase_changed)
+	PhaseManager.on_combat_phase_changed.connect(_on_phase_changed)
 
 
 func init_card(in_card_data: CardBase) -> void:
@@ -25,9 +25,9 @@ func init_card(in_card_data: CardBase) -> void:
 			break
 
 
-func _on_phase_changed(new_phase: GlobalEnums.Phase, _old_phase: GlobalEnums.Phase) -> void:
+func _on_phase_changed(new_phase: GlobalEnums.CombatPhase, _old_phase: GlobalEnums.CombatPhase) -> void:
 	# enable clicks on card only if player is in attack phase
-	get_click_handler().set_interactable(new_phase == GlobalEnums.Phase.PLAYER_ATTACKING)
+	get_click_handler().set_interactable(new_phase == GlobalEnums.CombatPhase.PLAYER_ATTACKING)
 
 
 func get_card_movement_component() -> CardMovementComponent:

--- a/Cards/Resource/Card_Poison.tres
+++ b/Cards/Resource/Card_Poison.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="CardBase" load_steps=17 format=3 uid="uid://ctx8jsvac84so"]
 
 [ext_resource type="Script" path="res://Cards/Effects/EffectApplyStatus.gd" id="1_5lji7"]
-[ext_resource type="PackedScene" path="res://Cards/Animation/Scene/Anim_Poison.tscn" id="1_q5mb6"]
+[ext_resource type="PackedScene" uid="uid://c13302ahcfpuy" path="res://Cards/Animation/Scene/Anim_Poison.tscn" id="1_q5mb6"]
 [ext_resource type="Script" path="res://Cards/CardBase.gd" id="1_u6k7h"]
 [ext_resource type="Script" path="res://Status/Debuffs/Debuff_Poison.gd" id="2_6vdl1"]
 [ext_resource type="Script" path="res://Cards/Effects/EffectData.gd" id="2_omhae"]

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -21,7 +21,8 @@ func _ready() -> void:
 		PlayerManager.on_player_initialized.connect(_on_player_initialized)
 	else:
 		_on_player_initialized()
-		
+	
+	PhaseManager.start_combat()
 	PhaseManager.on_combat_phase_changed.connect(_on_phase_changed)
 	CardManager.on_card_container_initialized.connect(_on_card_container_initialized)
 	CardManager.on_card_action_finished.connect(_handle_deaths.unbind(1))

--- a/Core/Battler.gd
+++ b/Core/Battler.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 	else:
 		_on_player_initialized()
 		
-	PhaseManager.on_phase_changed.connect(_on_phase_changed)
+	PhaseManager.on_combat_phase_changed.connect(_on_phase_changed)
 	CardManager.on_card_container_initialized.connect(_on_card_container_initialized)
 	CardManager.on_card_action_finished.connect(_handle_deaths.unbind(1))
 
@@ -49,11 +49,11 @@ func _on_player_initialized() -> void:
 		player_status_comp.add_status(buff, PlayerManager.player)
 
 
-func _on_phase_changed(new_phase: GlobalEnums.Phase, _old_phase: GlobalEnums.Phase) -> void:
-	if new_phase == GlobalEnums.Phase.PLAYER_ATTACKING:
+func _on_phase_changed(new_phase: GlobalEnums.CombatPhase, _old_phase: GlobalEnums.CombatPhase) -> void:
+	if new_phase == GlobalEnums.CombatPhase.PLAYER_ATTACKING:
 		_on_player_start_turn()
 	
-	if new_phase == GlobalEnums.Phase.ENEMY_ATTACKING:
+	if new_phase == GlobalEnums.CombatPhase.ENEMY_ATTACKING:
 		_on_enemy_start_turn()
 
 
@@ -63,7 +63,7 @@ func _on_card_container_initialized() -> void:
 
 
 func _on_player_hand_discarded() -> void:
-	PhaseManager.set_phase(GlobalEnums.Phase.ENEMY_ATTACKING)
+	PhaseManager.advance_to_next_combat_phase()
 
 
 ## player start phase: apply status
@@ -123,7 +123,7 @@ func _try_finish_enemy_attacks() -> void:
 	if _enemy_action_list.size() > 0:
 		_handle_enemy_attack_queue()
 	else:
-		PhaseManager.set_phase(GlobalEnums.Phase.PLAYER_ATTACKING)
+		PhaseManager.advance_to_next_combat_phase()
 
 
 ## when player clicks themselves (eg: healing card)

--- a/Entity/Components/HealthComponent.gd
+++ b/Entity/Components/HealthComponent.gd
@@ -103,12 +103,12 @@ func _set_block(new_block: int) -> void:
 	current_block = new_block
 	on_block_changed.emit(current_block)
 
-func reset_block_on_round_start(new_phase: GlobalEnums.Phase, _old_phase: GlobalEnums.Phase) -> void:
+func reset_block_on_round_start(new_phase: GlobalEnums.CombatPhase, _old_phase: GlobalEnums.CombatPhase) -> void:
 	if(team == GlobalEnums.Team.FRIENDLY):
-		if(new_phase == GlobalEnums.Phase.PLAYER_ATTACKING):
+		if(new_phase == GlobalEnums.CombatPhase.PLAYER_ATTACKING):
 			reset_block()
 	if(team == GlobalEnums.Team.ENEMY):
-		if(new_phase == GlobalEnums.Phase.ENEMY_ATTACKING):
+		if(new_phase == GlobalEnums.CombatPhase.ENEMY_ATTACKING):
 			reset_block()
 
 ## Sets block to 0 [br]

--- a/Entity/Enemy/Enemy.gd
+++ b/Entity/Enemy/Enemy.gd
@@ -7,13 +7,13 @@ class_name Enemy
 ## Connect the enemy to the [PhaseManager] to make it attack when it's its turn.
 func _ready() -> void:
 	super()
-	PhaseManager.on_phase_changed.connect(_on_phase_changed)
+	PhaseManager.on_combat_phase_changed.connect(_on_phase_changed)
 	get_stress_component().init_entity_component(self)
 
 
 ## Only allow the player to interact with enemies when it's the player turn
-func _on_phase_changed(new_phase: GlobalEnums.Phase, _old_phase: GlobalEnums.Phase) -> void:
-	get_click_handler().set_interactable(new_phase == GlobalEnums.Phase.PLAYER_ATTACKING)
+func _on_phase_changed(new_phase: GlobalEnums.CombatPhase, _old_phase: GlobalEnums.CombatPhase) -> void:
+	get_click_handler().set_interactable(new_phase == GlobalEnums.CombatPhase.PLAYER_ATTACKING)
 
 ## Used to get the enemy AI [br]
 ## Not in [Entity] as this is specific to enemies

--- a/Event/EventBase.gd
+++ b/Event/EventBase.gd
@@ -35,6 +35,7 @@ func get_event_name() -> String:
 ## What to do once the event starts
 func on_event_started() -> void:
 	PlayerManager.is_map_movement_allowed = false
+	PhaseManager.set_global_phase(GlobalEnums.GlobalPhase.SCENE_STARTED)
 	
 ## What to do once the event ends
 func on_event_ended() -> void:

--- a/Global/Global_Enums.gd
+++ b/Global/Global_Enums.gd
@@ -2,15 +2,19 @@ extends Node
 class_name GlobalEnums
 ## Global enums list
 
-## Where are we in the fight
-enum Phase
-{
+## For phases that are common between multiple events
+enum GlobalPhase {
 	NONE, ## Hello Youston, we are nowhere
 	GAME_STARTING, ## The game is starting
+	SCENE_STARTED, ## A new scene started
+	SCENE_END, ## The current scene ended
+}
+
+## For phases that are combat specific
+enum CombatPhase {
 	PLAYER_ATTACKING, ## The player is attacking
 	PLAYER_FINISHING, ## The player finished its turn (card discard and other stuff starts here)
 	ENEMY_ATTACKING, ## Enemy turn
-	SCENE_END, ## The current scene ended
 }
 
 ## In which team is an entity

--- a/Managers/PhaseManager.gd
+++ b/Managers/PhaseManager.gd
@@ -7,7 +7,8 @@ extends Node
 
 
 signal on_game_start
-signal on_phase_changed(new_phase: GlobalEnums.Phase, old_phase: GlobalEnums.Phase)
+signal on_combat_phase_changed(new_phase: GlobalEnums.CombatPhase, old_phase: GlobalEnums.CombatPhase)
+signal on_global_phase_changed(new_phase: GlobalEnums.GlobalPhase, old_phase: GlobalEnums.GlobalPhase)
 ## When a player wins the event
 signal on_event_win
 ## When the player is dead (reduced to 0 health)
@@ -15,10 +16,11 @@ signal on_defeat
 
 ## This is a signal is a temporary solution to block removal while #118 and #120 are done
 ## should be removed with those issues
-signal temp_before_phase_changed(new_phase: GlobalEnums.Phase, old_phase: GlobalEnums.Phase)
+signal temp_before_phase_changed(new_phase: GlobalEnums.CombatPhase, old_phase: GlobalEnums.CombatPhase)
 
-var current_phase: GlobalEnums.Phase = GlobalEnums.Phase.NONE
-
+var current_combat_phase: GlobalEnums.CombatPhase = GlobalEnums.CombatPhase.PLAYER_ATTACKING
+var current_combat_phase_index: int = 0
+var current_global_phase: GlobalEnums.GlobalPhase = GlobalEnums.GlobalPhase.NONE
 
 func _ready() -> void:
 	# initialize_game()
@@ -26,7 +28,7 @@ func _ready() -> void:
 	
 
 func initialize_game() -> void:
-	set_phase(GlobalEnums.Phase.GAME_STARTING)
+	set_global_phase(GlobalEnums.GlobalPhase.GAME_STARTING)
 	
 	# TODO give all objects some time to initialize. Kinda hacky
 	await get_tree().create_timer(.1).timeout
@@ -34,18 +36,35 @@ func initialize_game() -> void:
 
 
 func _start_game() -> void:
-	set_phase(GlobalEnums.Phase.PLAYER_ATTACKING)
+	_set_combat_phase(GlobalEnums.CombatPhase.PLAYER_ATTACKING)
 	on_game_start.emit()
 
 
 ## Change phases in the game (mainly used in combat for now)
-func set_phase(phase: GlobalEnums.Phase) -> void:
-	if (current_phase == phase):
-		return
-	
-	var old_phase: GlobalEnums.Phase = current_phase
+func _set_combat_phase(phase: GlobalEnums.CombatPhase) -> void:
+	# allow old phase being same as new phase
+	# this is if you finish a fight on player turn, you start the next also on player turn
+		
+	var old_phase: GlobalEnums.CombatPhase = current_combat_phase
 	
 	temp_before_phase_changed.emit(phase, old_phase)
 	
-	current_phase = phase
-	on_phase_changed.emit(current_phase, old_phase)
+	current_combat_phase = phase
+	on_combat_phase_changed.emit(current_combat_phase, old_phase)
+	
+func start_combat() -> void:
+	current_combat_phase_index = 0
+	_set_combat_phase(GlobalEnums.CombatPhase.values()[0])
+	
+func advance_to_next_combat_phase() -> void:
+	var combat_phase: Array = GlobalEnums.CombatPhase.values()
+	# advance the index by 1, going back to 0 if the index is bigger than the total number of possible phase
+	current_combat_phase_index = (current_combat_phase_index + 1) % (combat_phase.size())
+	_set_combat_phase(GlobalEnums.CombatPhase.values()[current_combat_phase_index])
+	
+func set_global_phase(phase: GlobalEnums.GlobalPhase) -> void:
+	if (current_global_phase == phase):
+		return
+	var old_phase: GlobalEnums.GlobalPhase = current_global_phase
+	current_global_phase = phase
+	on_global_phase_changed.emit(current_global_phase, old_phase)

--- a/Managers/PhaseManager.gd
+++ b/Managers/PhaseManager.gd
@@ -27,6 +27,7 @@ func _ready() -> void:
 	return
 	
 
+## Init phase
 func initialize_game() -> void:
 	set_global_phase(GlobalEnums.GlobalPhase.GAME_STARTING)
 	
@@ -35,6 +36,7 @@ func initialize_game() -> void:
 	_start_game()
 
 
+## Start the game
 func _start_game() -> void:
 	_set_combat_phase(GlobalEnums.CombatPhase.PLAYER_ATTACKING)
 	on_game_start.emit()
@@ -51,17 +53,21 @@ func _set_combat_phase(phase: GlobalEnums.CombatPhase) -> void:
 	
 	current_combat_phase = phase
 	on_combat_phase_changed.emit(current_combat_phase, old_phase)
-	
+
+## Call to setup combat phase [br]
+## Note: This might be used later to also properly remove block from previous fights
 func start_combat() -> void:
 	current_combat_phase_index = 0
 	_set_combat_phase(GlobalEnums.CombatPhase.values()[0])
 	
+## Go to the next phase of the combat
 func advance_to_next_combat_phase() -> void:
 	var combat_phase: Array = GlobalEnums.CombatPhase.values()
 	# advance the index by 1, going back to 0 if the index is bigger than the total number of possible phase
 	current_combat_phase_index = (current_combat_phase_index + 1) % (combat_phase.size())
 	_set_combat_phase(GlobalEnums.CombatPhase.values()[current_combat_phase_index])
 	
+## Used to set global game phase
 func set_global_phase(phase: GlobalEnums.GlobalPhase) -> void:
 	if (current_global_phase == phase):
 		return

--- a/Tests/test_health.gd
+++ b/Tests/test_health.gd
@@ -41,7 +41,7 @@ func test_reset_block_on_round_start() -> void:
 	var caster: Entity = _player
 	
 	_player_health_component.add_block(block_amount, caster)
-	PhaseManager.temp_before_phase_changed.emit(GlobalEnums.Phase.PLAYER_ATTACKING, GlobalEnums.Phase.ENEMY_ATTACKING)
+	PhaseManager.temp_before_phase_changed.emit(GlobalEnums.CombatPhase.PLAYER_ATTACKING, GlobalEnums.CombatPhase.ENEMY_ATTACKING)
 	assert_eq(_player_health_component.current_block, 0)
 
 func test_take_lots_of_damage() -> void:

--- a/UI/EndTurnButton.gd
+++ b/UI/EndTurnButton.gd
@@ -4,13 +4,13 @@ extends Button
 
 func _process(_delta: float) -> void:
 	# disable button during enemy attack phase
-	disabled = GlobalEnums.Phase.ENEMY_ATTACKING == PhaseManager.current_phase\
-				or PhaseManager.current_phase == GlobalEnums.Phase.PLAYER_FINISHING\
-				or (PhaseManager.current_phase == GlobalEnums.Phase.PLAYER_ATTACKING\
+	disabled = GlobalEnums.CombatPhase.ENEMY_ATTACKING == PhaseManager.current_combat_phase\
+				or PhaseManager.current_combat_phase == GlobalEnums.CombatPhase.PLAYER_FINISHING\
+				or (PhaseManager.current_combat_phase == GlobalEnums.CombatPhase.PLAYER_ATTACKING\
 				and (CardManager.card_container.are_cards_dealing()\
 				or CardManager.card_container.is_card_queued()\
 				or CardManager.card_container.are_cards_active()))
 
 
 func _on_pressed() -> void:
-	PhaseManager.set_phase(GlobalEnums.Phase.PLAYER_FINISHING)
+	PhaseManager.advance_to_next_combat_phase()


### PR DESCRIPTION
# Description

The phase manager now is the one doing the phase changes for combat phase, instead of the phase being set from outside. This allows (in theory) to add new phases to the combat phase and the phase manager will automatically go through those without need for more code.

You still need to call `advance_to_next_combat_phase` at the correct places, but you don't need to worry about what the next phase actually is.

## Related issue(s)
Closes #118 

## List of changes

- Split the `Phase` enum into `GlobalPhase` and `CombatPhase`
- Rewrite `PhaseManager` to go to next combat phase by calling `advance_to_next_combat_phase`
- Replace all instances of `Phase` by either `CombatPhase` or `GlobalPhase`
- Replace all instances of `set_phase` by either `advance_to_next_combat_phase` or `set_global_phase`

## Tests

Updated to work with the new phase system.

## Additional notes

This will help solving #120 
