### PR TITLE
Fixed softlock from trying to return to main menu on first map selection by not letting the function go through if its the only scene.

### DIFF
--- a/UI/MapUI.gd
+++ b/UI/MapUI.gd
@@ -31,7 +31,7 @@ var current_player_room: RoomUI
 var light_overlay: LightOverlay
 
 func _input(_inputevent: InputEvent) -> void:
-	if (_inputevent.is_action_pressed("cancel_action")):
+	if (_inputevent.is_action_pressed("cancel_action") and get_parent() != get_tree().root):
 		queue_free()
 
 


### PR DESCRIPTION

# Description

All this changed was a single line in an if statement adding another condition. if it sees that the parent scene is root then it doesn't allow for queue_free() to run.

## Related issue(s)

https://github.com/Saplings-Projects/1M_sub/issues/122 

## List of changes

Can be found in the the file: MapUI on line 34

## Tests

no test scripts written

## Additional notes

If you have anything more to add.
