### PR TITLE
Changed "inventory_HUD" to be attached to current scene instead of to inventoryManager

### DIFF
--- a/Managers/InventoryManager.gd
+++ b/Managers/InventoryManager.gd
@@ -17,7 +17,7 @@ var instanced_inventory_HUD : Node
 
 func instance_inventory_HUD() -> void:
 	instanced_inventory_HUD = inventory_HUD.instantiate()
-	add_child(instanced_inventory_HUD)
+	get_tree().current_scene.add_child(instanced_inventory_HUD)
 
 func close_inventory_HUD() -> void:
 	if(instanced_inventory_HUD == null):


### PR DESCRIPTION
# Description

Changed the instantiation of the inventory_HUD to be on the current scene instead of being created as a child to the current scene. This means if you leave the current scene the inventory menu will go away instead of staying.

## Related issue(s)

If your pull request is in link with an existing issue, please put a link to the issue here.

https://github.com/Saplings-Projects/1M_sub/issues/130 

## List of changes

Can be found in InventoryManager.gd line 20. 

## Tests

No tests created